### PR TITLE
Removes reset variables from mesh processing

### DIFF
--- a/vibra/engine/mesher/mesh.py
+++ b/vibra/engine/mesher/mesh.py
@@ -223,7 +223,6 @@ class Mesh:
         """
         Transform gmsh data in a more manageable format (aka nodal coords and connectivity).
         """
-        self.reset_variables()
         indexes, coords, _ = gmsh.model.mesh.getNodes(includeBoundary=True)
         total_nodes = int(np.max(indexes))
         self.nodal_coordinates = np.zeros((total_nodes, 4))
@@ -233,6 +232,10 @@ class Mesh:
         connectivity_dim1 = dict()
         connectivity_dim2 = dict()
         connectivity_dim3 = dict()
+
+        self.nodes_from_lines.clear()
+        self.nodes_from_surfaces.clear()
+        self.nodes_from_volumes.clear()
 
         for dim, tag in gmsh.model.getEntities():
             if dim == 3:


### PR DESCRIPTION
This very weird bug was introduced in commit d362b708c41e67606f28c989780dcb6a75177024. 
By reseting the variables, the connectivity of the mesh was set wrong.

I actually don't have a clue of why this happened, but it is a very good ilustration of how important automatic tests. This bug came out of nowhere and lived with us for a month without being noticed.

