### PR TITLE
Bugfix in AcousticAssembler.show_required_memory method call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ __pycache__/
 *.json
 
 # Distribution / packaging
+.idea/
 .vscode/
 .Python
 build/

--- a/vibra/engine/assemblers/acoustic_assembler.py
+++ b/vibra/engine/assemblers/acoustic_assembler.py
@@ -19,14 +19,15 @@ import numpy as np
 
 from collections import defaultdict
 
-from scipy.sparse import coo_matrix, csr_matrix
-from scipy.special import jv
+from scipy.sparse import csr_matrix
 from sys import getsizeof
 from time import time
 
 
 class AcousticAssembler:
     def __init__(self, model : Model):
+        self.ind_rows_Z = np.array([])
+        self.ind_cols_Z = np.array([])
         self.model = model
         self.properties = model.properties
 


### PR DESCRIPTION
In case of no acoustic damping 'ind_row_Z' and 'ind_col_Z' attributes are not initiated causing error in AcousticAssembler.show_required_memory method call.