### PR TITLE
Improve efficiency of frequency dependent acoustic assembler

### DIFF
--- a/vibra/engine/assemblers/acoustic_assembler.py
+++ b/vibra/engine/assemblers/acoustic_assembler.py
@@ -1053,11 +1053,17 @@ class AcousticAssembler:
     def assemble_global_stiffness_matrix(self, factor_K: np.ndarray):
         """
         """
+        t0 = time()
+
         data_K = self.data_K * factor_K
         if self.stiffness_matrix_full is None:
             self.stiffness_matrix_full = csr_matrix((data_K.flatten(), (self.ind_rows, self.ind_cols)), shape=(self.total_dofs, self.total_dofs))
         else:
             self.stiffness_matrix_full.data = data_K
+
+        dt = time() - t0
+        print()
+        print(f"Elapsed time to assemble stiffness matrix (test): {dt : .6f}")
 
         self.stiffness_matrix = self.stiffness_matrix_full[self.unprescribed_indexes, :][:, self.unprescribed_indexes]
         self.stiffness_matrix_r = self.stiffness_matrix_full[:, self.prescribed_indexes]
@@ -1066,11 +1072,17 @@ class AcousticAssembler:
     def assemble_global_mass_matrix(self, factor_M: np.ndarray):
         """
         """
+        t0 = time()
+
         data_M = self.data_M * factor_M
-        if self.mass_matrix_full:
+        if self.mass_matrix_full is None:
             self.mass_matrix_full = csr_matrix((data_M.flatten(), (self.ind_rows, self.ind_cols)), shape=(self.total_dofs, self.total_dofs))
         else:
             self.mass_matrix_full.data = data_M
+
+        dt = time() - t0
+        print()
+        print(f"Elapsed time to assemble mass matrix (test): {dt : .6f}")
 
         self.mass_matrix = self.mass_matrix_full[self.unprescribed_indexes, :][:, self.unprescribed_indexes]
         self.mass_matrix_r = self.mass_matrix_full[:, self.prescribed_indexes]

--- a/vibra/engine/assemblers/acoustic_assembler.py
+++ b/vibra/engine/assemblers/acoustic_assembler.py
@@ -39,18 +39,21 @@ class AcousticAssembler:
 
     def reset(self):
         self.frequency_dependent = False
-        self.stiffness_matrix = None
-        self.mass_matrix = None
-        self.damping_matrix = None
-        self.mass_flow_vectors = None
         self.frequencies = None
         self.number_frequencies = 1
         self.prescribed_values = list()
         self.prescribed_indexes = list()
         self.unprescribed_indexes = list()
+        self.reset_global_matrices_and_vectors()
 
+
+    def reset_global_matrices_and_vectors(self):
         self.stiffness_matrix_full = None
         self.mass_matrix_full = None
+        self.stiffness_matrix = None
+        self.mass_matrix = None
+        self.damping_matrix = None
+        self.mass_flow_vectors = None
 
 
     def get_element(self):
@@ -1324,6 +1327,7 @@ class AcousticAssembler:
 
     def process_assemble(self):
 
+        self.reset_global_matrices_and_vectors()
         self.update_number_of_frequencies()
 
         logging.info("Gathering data to assemble global matrices... [10/100]")

--- a/vibra/engine/assemblers/acoustic_assembler.py
+++ b/vibra/engine/assemblers/acoustic_assembler.py
@@ -584,25 +584,75 @@ class AcousticAssembler:
         self.process_indexes()
 
 
-    def _get_reordering_indexes(self, rows: np.ndarray, cols: np.ndarray):
+    def _get_reordering_indexes(self, rows: np.ndarray, cols: np.ndarray) -> np.ndarray:
+        """
+        This method returns the indexes to reorder the sparse matrices in such
+        a way that the rows and columns are lexically sorted and all data that
+        are on the same position are grouped together into a single index.
+
+        Parameters
+        ----------
+        rows: np.ndarray
+            Array with the rows of the sparse matrix.
+            It is assumed to be a 1D array.
+
+        cols: np.ndarray
+            Array with the columns of the sparse matrix.
+            It is assumed to be a 1D array.
+
+        returns
+        -------
+        np.ndarray
+            Array with the indexes to reorder the sparse matrices.
+        """
+
+        # Sorts rows and columns according to lexicographic order
         order: np.ndarray = np.lexsort((cols, rows))
+        rows: np.ndarray = rows[order]
+        cols: np.ndarray = cols[order]
+        
+        # Creates the indexes to "unsort" the data sorted with the previous indexes
         inverse_ordering = np.empty_like(order)
         inverse_ordering[order] = np.arange(len(order))
 
-        rows: np.ndarray = rows[order]
-        cols: np.ndarray = cols[order]
-
+        # Identifies repeated rows and columns
         repeated = np.ones_like(rows, dtype=bool)
         repeated[0] = False
         repeated[1:] &= rows[1:] == rows[:-1]
         repeated[1:] &= cols[1:] == cols[:-1]
 
+        # Assigns a unique index to each repeated row and column
         unified_indexes = np.cumsum(~repeated) - 1
         reordering = unified_indexes[inverse_ordering] 
         return reordering
 
 
-    def _reorder_data(self, data: np.ndarray, reordering: np.ndarray, target: np.ndarray | None = None):
+    def _reorder_data(self, data: np.ndarray, reordering: np.ndarray, target: np.ndarray | None = None) -> np.ndarray:
+        """
+        This method reorders the data according to the provided indexes, 
+        summing values that occur in the same position.
+        If no target is provided, it creates a zeroed array and use it.
+
+        Parameters
+        ---------
+        data: np.ndarray
+            The data to be reordered.
+            It is assumed to be a 1D array.
+
+        reordering: np.ndarray
+            The indexes to reorder the data.
+            It is assumed to be a 1D array.
+
+        target: np.ndarray, optional
+            The target array to store the reordered data.
+            It is assumed to be a 1D array.
+
+        Returns
+        -------
+        target: np.ndarray
+            The target array with the reordered data.
+        """
+
         if target is None:
             n_different_values = np.max(reordering) + 1
             target = np.zeros(n_different_values, data.dtype)

--- a/vibra/engine/assemblers/acoustic_assembler.py
+++ b/vibra/engine/assemblers/acoustic_assembler.py
@@ -1138,7 +1138,7 @@ class AcousticAssembler:
         if self.stiffness_matrix_full is None:
             self.stiffness_matrix_full = csr_matrix((data_K.flatten(), (self.ind_rows, self.ind_cols)), shape=(self.total_dofs, self.total_dofs))
         else:
-            self._reorder_data(data_K, self.reordering_indexes, target=self.mass_matrix_full.data)
+            self._reorder_data(data_K, self.reordering_indexes, target=self.stiffness_matrix_full.data)
 
         dt = time() - t0
         print()

--- a/vibra/engine/assemblers/acoustic_assembler.py
+++ b/vibra/engine/assemblers/acoustic_assembler.py
@@ -571,6 +571,7 @@ class AcousticAssembler:
 
         element_3D, _ = self.get_element()
         self.ind_rows, self.ind_cols = element_3D.generate_ind_rows_cols(reorder=reorder)
+        self.reordering_indexes = self._get_reordering_indexes(self.ind_rows, self.ind_cols) 
 
         self.dofs = element_3D.DOFS_PER_ELEMENT
         self.number_3d_elements = len(element_3D.connectivity)
@@ -582,6 +583,32 @@ class AcousticAssembler:
 
         self.process_fluid_properties_from_volumes()
         self.process_indexes()
+
+
+    def _get_reordering_indexes(self, rows: np.ndarray, cols: np.ndarray):
+        order: np.ndarray = np.lexsort((cols, rows))
+        rows: np.ndarray = rows[order]
+        cols: np.ndarray = cols[order]
+
+        repeated = np.ones_like(rows, dtype=bool)
+        repeated[0] = False
+        repeated[1:] &= rows[1:] == rows[:-1]
+        repeated[1:] &= cols[1:] == cols[:-1]
+
+        unified_indexes = np.cumsum(~repeated) - 1
+        reordering = unified_indexes[order.argsort()] 
+        return reordering
+
+
+    def _reorder_data(self, data: np.ndarray, reordering: np.ndarray, target: np.ndarray | None = None):
+        if target is None:
+            n_different_values = np.max(reordering) + 1
+            target = np.zeros(n_different_values, data.dtype)
+        else:
+            target *= 0
+
+        np.add.at(target, reordering, data.flatten())
+        return target
 
 
     def compute_global_matrices_factors(self, index: int = 0):
@@ -1059,7 +1086,7 @@ class AcousticAssembler:
         if self.stiffness_matrix_full is None:
             self.stiffness_matrix_full = csr_matrix((data_K.flatten(), (self.ind_rows, self.ind_cols)), shape=(self.total_dofs, self.total_dofs))
         else:
-            self.stiffness_matrix_full.data = data_K
+            self._reorder_data(data_K, self.reordering_indexes, target=self.mass_matrix_full.data)
 
         dt = time() - t0
         print()
@@ -1078,7 +1105,7 @@ class AcousticAssembler:
         if self.mass_matrix_full is None:
             self.mass_matrix_full = csr_matrix((data_M.flatten(), (self.ind_rows, self.ind_cols)), shape=(self.total_dofs, self.total_dofs))
         else:
-            self.mass_matrix_full.data = data_M
+            self._reorder_data(data_M, self.reordering_indexes, target=self.mass_matrix_full.data)
 
         dt = time() - t0
         print()

--- a/vibra/engine/assemblers/acoustic_assembler.py
+++ b/vibra/engine/assemblers/acoustic_assembler.py
@@ -586,6 +586,9 @@ class AcousticAssembler:
 
     def _get_reordering_indexes(self, rows: np.ndarray, cols: np.ndarray):
         order: np.ndarray = np.lexsort((cols, rows))
+        inverse_ordering = np.empty_like(order)
+        inverse_ordering[order] = np.arange(len(order))
+
         rows: np.ndarray = rows[order]
         cols: np.ndarray = cols[order]
 
@@ -595,7 +598,7 @@ class AcousticAssembler:
         repeated[1:] &= cols[1:] == cols[:-1]
 
         unified_indexes = np.cumsum(~repeated) - 1
-        reordering = unified_indexes[order.argsort()] 
+        reordering = unified_indexes[inverse_ordering] 
         return reordering
 
 

--- a/vibra/engine/assemblers/acoustic_assembler.py
+++ b/vibra/engine/assemblers/acoustic_assembler.py
@@ -49,6 +49,9 @@ class AcousticAssembler:
         self.prescribed_indexes = list()
         self.unprescribed_indexes = list()
 
+        self.stiffness_matrix_full = None
+        self.mass_matrix_full = None
+
 
     def get_element(self):
         element_type = self.model.mesh.element_type
@@ -1048,20 +1051,26 @@ class AcousticAssembler:
         """
         """
         data_K = self.data_K * factor_K
-        _stiffness_matrix_full = csr_matrix((data_K.flatten(), (self.ind_rows, self.ind_cols)), shape=(self.total_dofs, self.total_dofs))
+        if self.stiffness_matrix_full is None:
+            self.stiffness_matrix_full = csr_matrix((data_K.flatten(), (self.ind_rows, self.ind_cols)), shape=(self.total_dofs, self.total_dofs))
+        else:
+            self.stiffness_matrix_full.data = data_K
 
-        self.stiffness_matrix = _stiffness_matrix_full[self.unprescribed_indexes, :][:, self.unprescribed_indexes]
-        self.stiffness_matrix_r = _stiffness_matrix_full[:, self.prescribed_indexes]
+        self.stiffness_matrix = self.stiffness_matrix_full[self.unprescribed_indexes, :][:, self.unprescribed_indexes]
+        self.stiffness_matrix_r = self.stiffness_matrix_full[:, self.prescribed_indexes]
 
 
     def assemble_global_mass_matrix(self, factor_M: np.ndarray):
         """
         """
         data_M = self.data_M * factor_M
-        _mass_matrix_full = csr_matrix((data_M.flatten(), (self.ind_rows, self.ind_cols)), shape=(self.total_dofs, self.total_dofs))
+        if self.mass_matrix_full:
+            self.mass_matrix_full = csr_matrix((data_M.flatten(), (self.ind_rows, self.ind_cols)), shape=(self.total_dofs, self.total_dofs))
+        else:
+            self.mass_matrix_full.data = data_M
 
-        self.mass_matrix = _mass_matrix_full[self.unprescribed_indexes, :][:, self.unprescribed_indexes]
-        self.mass_matrix_r = _mass_matrix_full[:, self.prescribed_indexes]
+        self.mass_matrix = self.mass_matrix_full[self.unprescribed_indexes, :][:, self.unprescribed_indexes]
+        self.mass_matrix_r = self.mass_matrix_full[:, self.prescribed_indexes]
 
 
     def assemble_global_damping_matrix_3d_elements(self):

--- a/vibra/engine/assemblers/acoustic_assembler.py
+++ b/vibra/engine/assemblers/acoustic_assembler.py
@@ -24,7 +24,6 @@ import numpy as np
 from collections import defaultdict
 
 from scipy.sparse import csr_matrix
-from sys import getsizeof
 from time import time
 
 
@@ -792,7 +791,7 @@ class AcousticAssembler:
         if not self.integration_data_Zsi:
             return
 
-        logging.info(f"Processing the impedance data to assemble damping matrix... [1/10]")
+        logging.info("Processing the impedance data to assemble damping matrix... [1/10]")
         connectivities = self.integration_data_Zsi.get("connectivities")       
         surface_data = self.integration_data_Zsi.get("surface_data")
 
@@ -800,7 +799,7 @@ class AcousticAssembler:
         for j in range(self.number_frequencies):
             self.data_Zsi[j] = np.zeros((nel, dofs, dofs), dtype=complex)
 
-        logging.info(f"Processing the impedance data to assemble damping matrix... [2/10]")
+        logging.info("Processing the impedance data to assemble damping matrix... [2/10]")
         self.ind_rows_Zsi, self.ind_cols_Zsi = element_2D.generate_ind_rows_cols(connectivities)
         normalized_matrix_Ze = element_2D.stacked_damping_matrices_Ce()
 
@@ -832,7 +831,7 @@ class AcousticAssembler:
         if not self.integration_data_pw:
             return
 
-        logging.info(f"Processing the impedance data to assemble damping matrix... [1/10]")
+        logging.info("Processing the impedance data to assemble damping matrix... [1/10]")
         _k_wave = self.integration_data_pw.get("k_wave")
         _e_normals = self.integration_data_pw.get("e_normals")
         _pressures = self.integration_data_pw.get("pressures")
@@ -847,7 +846,7 @@ class AcousticAssembler:
         for j in range(self.number_frequencies):
             self.data_Zpw[j] = np.zeros((nel, dofs, dofs), dtype=complex)
 
-        logging.info(f"Processing the impedance data to assemble damping matrix... [2/10]")
+        logging.info("Processing the impedance data to assemble damping matrix... [2/10]")
         self.ind_rows_Zpw, self.ind_cols_Zpw = element_2D.generate_ind_rows_cols(connectivities)
         normalized_matrix_Ze = element_2D.stacked_damping_matrices_Ce()
         # eface_normals = element_2D.get_stacked_element_face_normals()
@@ -892,7 +891,7 @@ class AcousticAssembler:
         if not self.integration_data_Zas:
             return
         
-        logging.info(f"Processing the impedance data to assemble damping matrix... [3/10]")
+        logging.info("Processing the impedance data to assemble damping matrix... [3/10]")
         connectivities = self.integration_data_Zas.get("connectivities")       
         surface_data = self.integration_data_Zas.get("surface_data")
 
@@ -900,7 +899,7 @@ class AcousticAssembler:
         for j in range(self.number_frequencies):
             self.data_Zas[j] = np.zeros((nel, dofs, dofs), dtype=complex)
 
-        logging.info(f"Processing the impedance data to assemble damping matrix... [4/10]")
+        logging.info("Processing the impedance data to assemble damping matrix... [4/10]")
         self.ind_rows_Zas, self.ind_cols_Zas = element_2D.generate_ind_rows_cols(connectivities)
         normalized_matrix_Ze = element_2D.stacked_damping_matrices_Ce()
 
@@ -937,7 +936,7 @@ class AcousticAssembler:
         if not self.integration_data_Zti:
             return
 
-        logging.info(f"Processing the impedance data to assemble damping matrix... [5/10]")
+        logging.info("Processing the impedance data to assemble damping matrix... [5/10]")
         connectivities_A = self.integration_data_Zti.get("connectivities_A")
         connectivities_B = self.integration_data_Zti.get("connectivities_B")
         surface_data_A = self.integration_data_Zti.get("surface_data_A")
@@ -950,7 +949,7 @@ class AcousticAssembler:
             self.data_Zti_A[j] = np.zeros((nel_A, dofs, dofs), dtype=complex)
             self.data_Zti_B[j] = np.zeros((nel_B, dofs, dofs), dtype=complex)
 
-        logging.info(f"Processing the impedance data to assemble damping matrix... [6/10]")
+        logging.info("Processing the impedance data to assemble damping matrix... [6/10]")
         self.ind_rows_Zti_A, self.ind_cols_Zti_A = element_2D.generate_ind_rows_cols(connectivities_A)
         normalized_matrix_Ze_A = element_2D.stacked_damping_matrices_Ce()
 
@@ -966,7 +965,7 @@ class AcousticAssembler:
         #     for j in range(self.number_frequencies):
         #         self.data_Zti_A[j][i, :, :] = normalized_matrix_Z / Z_tr[j]
 
-        logging.info(f"Processing the impedance data to assemble damping matrix... [7/10]")
+        logging.info("Processing the impedance data to assemble damping matrix... [7/10]")
         self.ind_rows_Zti_B, self.ind_cols_Zti_B = element_2D.generate_ind_rows_cols(connectivities_B)
         normalized_matrix_Ze_B = element_2D.stacked_damping_matrices_Ce()
 
@@ -1009,7 +1008,7 @@ class AcousticAssembler:
         if not self.integration_data_Zpp:
             return
         
-        logging.info(f"Processing the impedance data to assemble damping matrix... [8/10]")
+        logging.info("Processing the impedance data to assemble damping matrix... [8/10]")
 
         connectivities_A = self.integration_data_Zpp.get("connectivities_A")
         connectivities_B = self.integration_data_Zpp.get("connectivities_B")
@@ -1024,7 +1023,7 @@ class AcousticAssembler:
             self.data_Zpp_A[j] = np.zeros((nel_A, dofs, dofs), dtype=complex)
             self.data_Zpp_B[j] = np.zeros((nel_B, dofs, dofs), dtype=complex)
 
-        logging.info(f"Processing the impedance data to assemble damping matrix... [9/10]")
+        logging.info("Processing the impedance data to assemble damping matrix... [9/10]")
         self.ind_rows_Zpp_A, self.ind_cols_Zpp_A = element_2D.generate_ind_rows_cols(connectivities_A)
         normalized_matrix_Ze_A = element_2D.stacked_damping_matrices_Ce()
 
@@ -1046,7 +1045,7 @@ class AcousticAssembler:
         #     for j in range(self.number_frequencies):
         #         self.data_Zpp_A[j][i, :, :] = normalized_matrix_Z / Z_tr[j]
 
-        logging.info(f"Processing the impedance data to assemble damping matrix... [10/10]")
+        logging.info("Processing the impedance data to assemble damping matrix... [10/10]")
         self.ind_rows_Zpp_B, self.ind_cols_Zpp_B = element_2D.generate_ind_rows_cols(connectivities_B)
         normalized_matrix_Ze_B = element_2D.stacked_damping_matrices_Ce()
 

--- a/vibra/engine/mesher/mesh.py
+++ b/vibra/engine/mesher/mesh.py
@@ -996,7 +996,7 @@ class Mesh:
         self.solids_connectivity, self.map_solid_elements = self._get_connectivity_array(connectivity_dim3)
 
         self.process_mesh_related_mappings()
-        # self.loooking_for_collapsed_elements()
+        # self.looking_for_collapsed_elements()
 
 
     def cache_mesh_information(self):
@@ -1346,7 +1346,7 @@ class Mesh:
             self.solid_to_face_elements[solid_id].append(face_id)
 
 
-    def loooking_for_collapsed_elements(self):
+    def looking_for_collapsed_elements(self):
         """
         This method loops through all the elements' connectivities, searching for collapsed elements.
         A message will be printed whether some problematic connectivity has been detected.


### PR DESCRIPTION
Avoid the recreation of csr_matrix when only the data values need to be updated. The data update require a preprocessing step, but for typical configurations it should be advantageous.