### PR TITLE
Fixes behavior bug in magnification factor slider

### DIFF
--- a/vibra/interface/animation_toolbar.py
+++ b/vibra/interface/animation_toolbar.py
@@ -119,6 +119,7 @@ class AnimationToolbar(QToolBar):
 
         self.phase_slider.sliderPressed.connect(self.pause_animation)
         self.phase_slider.valueChanged.connect(self.phase_slider_callback)
+        self.magnification_factor_slider.sliderPressed.connect(self.pause_animation)
         self.magnification_factor_slider.valueChanged.connect(self.magnification_factor_slider_callback)
 
         self.pushButton_animate.clicked.connect(self.process_animation)
@@ -242,7 +243,7 @@ class AnimationToolbar(QToolBar):
             )
         else:
             app().main_window.results_widget.stop_animation()
-
+        
     def update_animate_button_icons(self, state: bool):
         if state:
             self.pushButton_animate.setIcon(self.pause_icon)


### PR DESCRIPTION
This PR fixes the behavior bug of the magnification factor slider when the user runs a structural analysis animation. To do this, when the user selects a new magnification factor, the animation stops, if it's running.

This PR closes the #132 issue.