### PR TITLE
Fix section plane during animation

### DIFF
--- a/vibra/interface/viewer_3d/actors/analysis_actor.py
+++ b/vibra/interface/viewer_3d/actors/analysis_actor.py
@@ -31,7 +31,7 @@ class AnalysisActor(SolidsActor):
 
         for i, val in enumerate(self.color_table.values_vector):
             color = self.color_table.get_color(val)
-            point_colors.SetTuple(i, color)
+            point_colors.SetTuple(i, color.to_rgba())
 
         self.data.Modified()
         self.GetMapper().SetScalarModeToUsePointData()

--- a/vibra/interface/viewer_3d/actors/hollow_analysis_actor.py
+++ b/vibra/interface/viewer_3d/actors/hollow_analysis_actor.py
@@ -30,7 +30,7 @@ class HollowAnalysisActor(HollowSolidsActor):
 
         for i, val in enumerate(self.color_table.values_vector):
             color = self.color_table.get_color(val)
-            point_colors.SetTuple(i, color)
+            point_colors.SetTuple(i, color.to_rgb())
 
         self.data.Modified()
         self.GetMapper().SetScalarModeToUsePointData()

--- a/vibra/interface/viewer_3d/coloring/color_table.py
+++ b/vibra/interface/viewer_3d/coloring/color_table.py
@@ -2,11 +2,11 @@ import numpy as np
 from vtkmodules.vtkCommonCore import vtkLookupTable
 from vtkmodules.vtkRenderingCore import vtkColorTransferFunction
 
+from molde.colors import Color
 from . import color_palettes
 
 
 class ColorTable(vtkLookupTable):
-
     def __init__(
         self,
         values_vector=None,
@@ -63,12 +63,12 @@ class ColorTable(vtkLookupTable):
             print(f'Invalid colormap "{self.colormap}". Using "viridis" instead.')
             self._set_colors(color_palettes.viridis_colors)
 
-    def get_color(self, value) -> tuple[int, int, int]:
-        # yes, vtk uses the list as a python pointer 
+    def get_color(self, value) -> Color:
+        # yes, vtk uses the list as a python pointer
         # instead of returning a tuple...
         tmp = [0, 0, 0]
         self.GetColor(np.real(value), tmp)
-        return tuple(int(i * 255) for i in tmp)
+        return Color.from_rgb_f(*tmp)
 
     def _set_colors(self, colors, shades=256):
         color_transfer = vtkColorTransferFunction()

--- a/vibra/interface/viewer_3d/render_widgets/results_render_widget.py
+++ b/vibra/interface/viewer_3d/render_widgets/results_render_widget.py
@@ -314,6 +314,7 @@ class ResultsRenderWidget(AnimatedRenderWidget):
             return
 
         section_plane = app().main_window.section_plane
+        self.stop_animation()
 
         if not section_plane.cutting:
             visualization = app().main_window.visualization_filter


### PR DESCRIPTION
This solves the bug reported internally by @vitorslongo, which happened when a section plane was applied during an animation. Besides the actual problem solving, I also opted to stop the animation during the cut, because it seems a more natural behavior. 

Please check if the problem was correctly solved and if the behavior looks correct.