### PR TITLE
Fix vibra icon

### DIFF
--- a/vibra/interface/main_window.py
+++ b/vibra/interface/main_window.py
@@ -146,6 +146,8 @@ class MainWindow(MainWindow_UI):
         self.setWindowTitle("Vibra")
         self.installEventFilter(self)
 
+        app().processEvents()
+
         # for qdarktheme
         self.custom_colors = {
             "[dark]": {
@@ -180,10 +182,6 @@ class MainWindow(MainWindow_UI):
 
         app().splash.close()
         self.showMaximized()
-        
-        # I have no idea why, but the definition on _config_window is not enough
-        # it need to be redefined here again to appear propperly
-        self.setWindowIcon(self.vibra_icon)
 
         app().processEvents()
 

--- a/vibra/interface/main_window.py
+++ b/vibra/interface/main_window.py
@@ -146,6 +146,7 @@ class MainWindow(MainWindow_UI):
         self.setWindowTitle("Vibra")
         self.installEventFilter(self)
 
+        # to ensure everything has been processed before proceeding
         app().processEvents()
 
         # for qdarktheme

--- a/vibra/interface/main_window.py
+++ b/vibra/interface/main_window.py
@@ -180,6 +180,10 @@ class MainWindow(MainWindow_UI):
 
         app().splash.close()
         self.showMaximized()
+        
+        # I have no idea why, but the definition on _config_window is not enough
+        # it need to be redefined here again to appear propperly
+        self.setWindowIcon(self.vibra_icon)
 
         app().processEvents()
 


### PR DESCRIPTION
This is just a small workarround to make the vibra icon actually appear, since it was not working on the previous `setWindowIcon` function call.

I still can not understand this behavior, but now it is working on my machine, please let me know if it works propperly on yours too.