### PR TITLE
fix recent files stack

### DIFF
--- a/vibra/interface/welcome_widget.py
+++ b/vibra/interface/welcome_widget.py
@@ -60,7 +60,7 @@ class WelcomeWidget(QWidget):
             
         number_of_recent = 7
         recent_paths = app().config.get_recent_files()
-        recent_paths = recent_paths[-number_of_recent:]
+        recent_paths = recent_paths[:number_of_recent]
 
         for path in recent_paths:
             path = Path(path)


### PR DESCRIPTION
This PR fixes the welcome widget recent files stack. Now, the recent files interface in the Welcome Widget works as expected.

Please, see if everything it's ok @andrefpf.