### PR TITLE
Reset partial solution to avoid post-processing errors

### DIFF
--- a/vibra/engine/solvers/harmonic_solver.py
+++ b/vibra/engine/solvers/harmonic_solver.py
@@ -18,6 +18,7 @@ class HarmonicSolver:
     def __init__(self, assembler: AcousticAssembler | StructuralAssembler, project_file: ProjectFile | None = None, **kwargs):
         self.assembler = assembler
         self.project_file = project_file
+
         self.reset_variables()
 
     def reset_variables(self):
@@ -66,21 +67,24 @@ class HarmonicSolver:
     def _closing_solution_handler(self, solution):
         if isinstance(solution, LazyHDF5MatrixWriter):
             solution.close()
-            self.solution = self.project_file.get_solution_loader()
+            if self.assembler.model.stop_processing:
+                self.reset_variables()
+            else:
+                self.solution = self.project_file.get_solution_loader()
         else:
             # reinsert the prescribed degrees of freedom into the solution vector
             self.solution = self.assembler.reinsert_the_prescribed_dof(solution)
 
-    def compute_frequency_sweep(self, solution, print_log, is_resume, modes=None):
+    def compute_frequency_sweep(self, solution, print_log, is_resume, eigenvectors=None):
+
         # frequencies vector [in hertz]
         frequencies = self.assembler.model.frequencies
-        
+
         # compute the solution for each frequency step
         for i, freq in enumerate(frequencies):
 
             if self.assembler.model.stop_processing:
-                self.reset_variables()
-                return True
+                return
 
             logging.info(f"Solution step {i + 1} and frequency {freq} Hz [{i + 1}/{len(frequencies)}]")
 
@@ -95,9 +99,9 @@ class HarmonicSolver:
             if freq == 0:
                 # In case of freq=0, the matrix may differ from the non-zero frequencies, so we solve it with
                 # a particular linear solver
-                linear_solver = self._get_linear_solver(modes, True)
+                linear_solver = self._get_linear_solver(eigenvectors, True)
             else:
-                linear_solver = self._get_linear_solver(modes)
+                linear_solver = self._get_linear_solver(eigenvectors)
 
             solution_freq = linear_solver.solve(A, f)
 
@@ -111,10 +115,10 @@ class HarmonicSolver:
             linear_solver.clear_memory()
             del A, f
 
-    def _get_linear_solver(self, modes, new_instance: bool = False) -> LinearSolver:
+    def _get_linear_solver(self, eigenvectors, new_instance: bool = False) -> LinearSolver:
         if self._linear_solver is None or new_instance:
-            if modes is not None:
-                linear_solver = initialize_solver(SolverType.MODAL_SUPERPOSITION, modes=modes)
+            if eigenvectors is not None:
+                linear_solver = initialize_solver(SolverType.MODAL_SUPERPOSITION, eigenvectors=eigenvectors)
             elif isinstance(self.assembler, StructuralAssembler):
                 linear_solver = initialize_solver(SolverType.PARDISO, is_symmetric=True)
             else:
@@ -134,12 +138,12 @@ class HarmonicSolver:
 
         t0 = time()        
         modal_solver = ModalSolver(self.assembler)
-        natural_frequencies, modes = modal_solver.solve(full_solution=False)
+        natural_frequencies, eigenvectors = modal_solver.solve(full_solution=False)
         dt = time() - t0
         print(f"Elapsed time to solve modal analysis: {dt : .6f} [s]")
 
         if is_proportionally_damped:
-            self.compute_proportionally_damped_frequency_sweep(solution, modes, natural_frequencies, print_log, is_resume)
+            self.compute_proportionally_damped_frequency_sweep(solution, eigenvectors, natural_frequencies, print_log, is_resume)
         else:
             self.compute_frequency_sweep(solution, print_log, is_resume)
 

--- a/vibra/engine/solvers/linear_solver.py
+++ b/vibra/engine/solvers/linear_solver.py
@@ -127,10 +127,10 @@ class MumpsLinearSolver(LinearSolver):
         return self._solver
     
 class ModalSuperpositionSolver(LinearSolver):
-    def __init__(self, modes, **kwargs):
+    def __init__(self, eigenvectors: np.ndarray, **kwargs):
         super().__init__(**kwargs)
-        self.Phi = modes
-        self.PhiH = modes.conj().T
+        self.Phi = eigenvectors
+        self.PhiH = eigenvectors.conj().T
         self.linear_operator_class = LinearOperator  # Not used
 
     def solve(self, A, F):
@@ -149,10 +149,10 @@ def initialize_solver(solver_type: SolverType, **kwargs) -> LinearSolver:
     elif solver_type == SolverType.MUMPS:
         return MumpsLinearSolver(**kwargs)
     elif solver_type == SolverType.MODAL_SUPERPOSITION:
-        modes = kwargs.get('modes')
-        if modes is None:
-            raise ValueError("Modes must be provided for Modal Superposition Solver.")
-        return ModalSuperpositionSolver(modes)
+        eigenvectors = kwargs.get("eigenvectors")
+        if eigenvectors is None:
+            raise ValueError("Eigenvectors must be provided for Modal Superposition Solver.")
+        return ModalSuperpositionSolver(eigenvectors)
     else:
         raise ValueError(f"Unknown solver type: {solver_type}")
 

--- a/vibra/engine/solvers/modal_solver.py
+++ b/vibra/engine/solvers/modal_solver.py
@@ -40,57 +40,56 @@ class ModalSolver:
 
         try:
             opinv = linear_solver.build_linear_operator(A - sigma * B)
-            eigen_values, eigen_vectors = eigs(A, M=B, k=n_modes, sigma=sigma, which=which, OPinv=opinv)
+            eigenvalues, eigenvectors = eigs(A, M=B, k=n_modes, sigma=sigma, which=which, OPinv=opinv)
             linear_solver.clear_memory()
 
         except Exception as error_log:
             from traceback import print_exception
             print_exception(error_log)
-            eigen_values, eigen_vectors = eigs(A, M=B, k=n_modes, sigma=sigma, which=which)
+            eigenvalues, eigenvectors = eigs(A, M=B, k=n_modes, sigma=sigma, which=which)
 
         if not is_symmetric:
             logging.info("Post-processing the solution... [95/100]")
 
-            n_dof = int(eigen_vectors.shape[0] / 2)
+            n_dof = int(eigenvectors.shape[0] / 2)
 
             # filtering the eigenvalues with positive imaginary part
-            mask = np.imag(eigen_values) > 0
-            eigen_values = eigen_values[mask]
-            eigen_vectors = eigen_vectors[:, mask]
+            mask = np.imag(eigenvalues) > 0
+            eigenvalues = eigenvalues[mask]
+            eigenvectors = eigenvectors[:, mask]
 
-            Wn = np.abs(eigen_values)
+            Wn = np.abs(eigenvalues)
             natural_frequencies = Wn / (2 * np.pi)
-            damping_ratio = -np.real(eigen_values) / Wn
+            damping_ratio = -np.real(eigenvalues) / Wn
 
             # reordering the eigenvalues and eigenvectors founded
             index_order = np.argsort(natural_frequencies)
             damping_ratio = damping_ratio[index_order]
             natural_frequencies = natural_frequencies[index_order]
-            complex_natural_frequencies = eigen_values[index_order] / (2 * np.pi)
+            complex_natural_frequencies = eigenvalues[index_order] / (2 * np.pi)
 
             # filtering the eigenvalues with damping ratio csi < 1
             mask_dmp = np.round(np.abs(damping_ratio), 6) < 1
             damping_ratio = damping_ratio[mask_dmp]
             self.natural_frequencies = natural_frequencies[mask_dmp]
-            self.solution = eigen_vectors[:n_dof, index_order][:, mask_dmp]
+            self.solution = eigenvectors[:n_dof, index_order][:, mask_dmp]
             self.complex_natural_frequencies = complex_natural_frequencies[mask_dmp]
 
         else:
             logging.info("Post-processing the solution... [95/100]")
 
-            Wn2 = np.absolute(np.real(eigen_values))
+            Wn2 = np.absolute(np.real(eigenvalues))
             natural_frequencies = np.sqrt(Wn2) / (2 * np.pi)
 
             # reordering the eigenvalues and eigenvectors founded
             index_order = np.argsort(natural_frequencies)
             self.natural_frequencies = natural_frequencies[index_order]
-            self.solution = eigen_vectors[:, index_order]
+            self.solution = eigenvectors[:, index_order]
 
         if full_solution:
             self.solution = self.assembler.reinsert_the_prescribed_dof(self.solution)
 
         if isinstance(self.assembler, StructuralAssembler):
             self.displacement_dof = self.assembler.displacement_dof
-
 
         return self.natural_frequencies, self.solution

--- a/vibra/interface/analysis/acoustic_modal_analysis_input.py
+++ b/vibra/interface/analysis/acoustic_modal_analysis_input.py
@@ -21,7 +21,7 @@ class AcousticModalAnalysisInput(AcousticModalAnalysisInput_UI):
         self._config_window()
         self._create_connections()
         self._load_analysis_setup()
-        self.check_for_collapsed_elements()
+        self.check_mesh_related_issues()
         self.exec()
 
     def _initialize(self):
@@ -55,18 +55,26 @@ class AcousticModalAnalysisInput(AcousticModalAnalysisInput_UI):
                 self.lineEdit_number_modes.setText(str(modes_number))
                 self.lineEdit_sigma_factor.setText(str(sigma))
 
-    def check_for_collapsed_elements(self):
-        mesh = app().project.model.mesh   
-        collapsed = (mesh.collapsed_3d_elements or mesh.collapsed_2d_elements or mesh.collapsed_1d_elements)
-        self.pushButton_run_analysis.setDisabled(bool(collapsed))
+    def check_mesh_related_issues(self):
+
+        # disable run_analysis button if there are disconnected nodes or collapsed elements
+        mesh = app().project.model.mesh
+        disconnected_nodes = bool(mesh.disconnected_nodes)
+        collapsed_elements = bool(mesh.collapsed_3d_elements or mesh.collapsed_2d_elements or mesh.collapsed_1d_elements)
 
         text = ""
-        if collapsed:
+        if collapsed_elements:
             text = "Collapsed elements have been detected during the mesh post-processing. \n"
             text += "The model solution will stay deactivated until the collapsed-related \n"
             text += "issues have been addressed."
 
+        if disconnected_nodes:
+            text += "Disconnected nodes have been detected during the mesh post-processing. \n"
+            text += "The model solution will stay deactivated until the meshing-related issues \n"
+            text += "have been addressed."
+
         self.pushButton_run_analysis.setToolTip(text)
+        self.pushButton_run_analysis.setDisabled(collapsed_elements or disconnected_nodes)
 
     def check_analysis_inputs(self):
 

--- a/vibra/interface/analysis/harmonic_analysis_setup_input.py
+++ b/vibra/interface/analysis/harmonic_analysis_setup_input.py
@@ -43,7 +43,7 @@ class HarmonicAnalysisSetupInput(HarmonicAnalysisSetupInput_UI):
 
         self.load_analysis_setup()
         self.update_harmonic_analysis_title()
-        self.check_for_collapsed_elements()
+        self.check_mesh_related_issues()
 
         while self.keep_window_open:
             self.exec()
@@ -152,18 +152,26 @@ class HarmonicAnalysisSetupInput(HarmonicAnalysisSetupInput_UI):
         elif self.analysis_id == AnalysisID.COUPLED_HARMONIC:
             self.label_title.setText("Coupled harmonic analysis setup")
 
-    def check_for_collapsed_elements(self):
-        mesh = app().project.model.mesh   
-        collapsed = (mesh.collapsed_3d_elements or mesh.collapsed_2d_elements or mesh.collapsed_1d_elements)
-        self.pushButton_run_analysis.setDisabled(bool(collapsed))
+    def check_mesh_related_issues(self):
+
+        # disable run_analysis button if there are disconnected nodes or collapsed elements
+        mesh = app().project.model.mesh
+        disconnected_nodes = bool(mesh.disconnected_nodes)
+        collapsed_elements = bool(mesh.collapsed_3d_elements or mesh.collapsed_2d_elements or mesh.collapsed_1d_elements)
 
         text = ""
-        if collapsed:
+        if collapsed_elements:
             text = "Collapsed elements have been detected during the mesh post-processing. \n"
             text += "The model solution will stay deactivated until the collapsed-related \n"
             text += "issues have been addressed."
 
+        if disconnected_nodes:
+            text += "Disconnected nodes have been detected during the mesh post-processing. \n"
+            text += "The model solution will stay deactivated until the meshing-related issues \n"
+            text += "have been addressed."
+
         self.pushButton_run_analysis.setToolTip(text)
+        self.pushButton_run_analysis.setDisabled(collapsed_elements or disconnected_nodes)
 
     def enter_setup_callback(self):
         # analysis_setup = app().file.read_analysis_setup_from_file()

--- a/vibra/interface/analysis/harmonic_analysis_setup_input.py
+++ b/vibra/interface/analysis/harmonic_analysis_setup_input.py
@@ -107,7 +107,7 @@ class HarmonicAnalysisSetupInput(HarmonicAnalysisSetupInput_UI):
 
         self.comboBox_method.blockSignals(True)
 
-        if self.analysis_id in [AnalysisID.ACOUSTIC_HARMONIC]:
+        if self.analysis_id == AnalysisID.ACOUSTIC_HARMONIC:
             self.comboBox_method.removeItem(1)
             self.tabWidget_main.setTabVisible(1, False)
 

--- a/vibra/interface/analysis/structural_modal_analysis_input.py
+++ b/vibra/interface/analysis/structural_modal_analysis_input.py
@@ -21,7 +21,7 @@ class StructuralModalAnalysisInput(ModalAnalysisInput_UI):
         self._config_window()
         self._create_connections()
         self._load_analysis_setup()
-        self.check_for_collapsed_elements()
+        self.check_mesh_related_issues()
         self.exec()
 
     def _initialize(self):
@@ -52,18 +52,26 @@ class StructuralModalAnalysisInput(ModalAnalysisInput_UI):
                 self.lineEdit_number_modes.setText(str(modes_number))
                 self.lineEdit_sigma_factor.setText(str(sigma))
 
-    def check_for_collapsed_elements(self):
-        mesh = app().project.model.mesh   
-        collapsed = (mesh.collapsed_3d_elements or mesh.collapsed_2d_elements or mesh.collapsed_1d_elements)
-        self.pushButton_run_analysis.setDisabled(bool(collapsed))
+    def check_mesh_related_issues(self):
+
+        # disable run_analysis button if there are disconnected nodes or collapsed elements
+        mesh = app().project.model.mesh
+        disconnected_nodes = bool(mesh.disconnected_nodes)
+        collapsed_elements = bool(mesh.collapsed_3d_elements or mesh.collapsed_2d_elements or mesh.collapsed_1d_elements)
 
         text = ""
-        if collapsed:
+        if collapsed_elements:
             text = "Collapsed elements have been detected during the mesh post-processing. \n"
             text += "The model solution will stay deactivated until the collapsed-related \n"
             text += "issues have been addressed."
 
+        if disconnected_nodes:
+            text += "Disconnected nodes have been detected during the mesh post-processing. \n"
+            text += "The model solution will stay deactivated until the meshing-related issues \n"
+            text += "have been addressed."
+
         self.pushButton_run_analysis.setToolTip(text)
+        self.pushButton_run_analysis.setDisabled(collapsed_elements or disconnected_nodes)
 
     def check_analysis_inputs(self):
 

--- a/vibra/interface/analysis_toolbar.py
+++ b/vibra/interface/analysis_toolbar.py
@@ -245,6 +245,9 @@ class AnalysisToolbar(QToolBar):
         if app().main_window.action_results_workspace.isChecked():
             app().main_window.action_model_workspace_callback()
 
+        app().main_window.action_results_workspace.setDisabled(True)
+        app().main_window.results_viewer_widget.clear_treeWidgets_of_frequencies()
+
         # Do not solve models with collapsed elements!
         mesh = app().project.model.mesh   
         collapsed = (mesh.collapsed_3d_elements or mesh.collapsed_2d_elements or mesh.collapsed_1d_elements)

--- a/vibra/interface/analysis_toolbar.py
+++ b/vibra/interface/analysis_toolbar.py
@@ -245,8 +245,12 @@ class AnalysisToolbar(QToolBar):
         if app().main_window.action_results_workspace.isChecked():
             app().main_window.action_model_workspace_callback()
 
-        # Do not solve models with collapsed elements!
+        # Do not solve models if there are disconnected nodes or collapsed elements!
         mesh = app().project.model.mesh   
+
+        if mesh.disconnected_nodes:
+            return
+
         collapsed = (mesh.collapsed_3d_elements or mesh.collapsed_2d_elements or mesh.collapsed_1d_elements)
         if collapsed:
             return
@@ -335,10 +339,12 @@ class AnalysisToolbar(QToolBar):
             elif physical_domain == "Acoustic":
                 self.modal_acoustic()
 
-        # disable run_analysis button if there are collapsed elements
-        mesh = app().project.model.mesh   
-        collapsed = (mesh.collapsed_3d_elements or mesh.collapsed_2d_elements or mesh.collapsed_1d_elements)
-        self.pushButton_run_analysis.setDisabled(bool(collapsed))
+        # disable run_analysis button if there are disconnected nodes or collapsed elements
+        mesh = app().project.model.mesh
+        disconnected_nodes = bool(mesh.disconnected_nodes)
+        collapsed_elements = bool(mesh.collapsed_3d_elements or mesh.collapsed_2d_elements or mesh.collapsed_1d_elements)
+
+        self.pushButton_run_analysis.setDisabled(collapsed_elements or disconnected_nodes)
 
     def harmonic_structural(self):
 

--- a/vibra/interface/main_window.py
+++ b/vibra/interface/main_window.py
@@ -10,12 +10,7 @@ from molde import stylesheets
 from molde.render_widgets import CommonRenderWidget
 from PySide6.QtCore import QEvent, Qt, Signal
 from PySide6.QtGui import QAction
-from PySide6.QtWidgets import (
-    QAbstractButton,
-    QFileDialog,
-    QMenu,
-    QMessageBox,
-)
+from PySide6.QtWidgets import QAbstractButton, QFileDialog, QMenu, QMessageBox
 
 from vibra import app, TEMP_PROJECT_DIR, SUPPORTED_GEOMETRY_EXTENSIONS, SUPPORTED_MESH_EXTENSIONS, LIGHT_ICON_COLOR
 from vibra.interface.analysis_toolbar import AnalysisToolbar

--- a/vibra/interface/menus/model_setup_items.py
+++ b/vibra/interface/menus/model_setup_items.py
@@ -161,8 +161,9 @@ class ModelSetupItems(CommonMenuItems):
     def _contains_property(self, property_name: str):
 
         model = app().project.model
+        mesh = app().project.model.mesh
         properties = app().project.model.properties
-        
+
         property_dicts = [
             properties.acoustic_imported_tables,
             properties.structural_imported_tables,
@@ -177,36 +178,36 @@ class ModelSetupItems(CommonMenuItems):
             ]
 
         if property_name == "material":
-            if model.mesh.are_there_volumes_in_geometry():
-                volume_ids = model.mesh.geometry_information.get("volumes")
-                volumes_without_material = model.properties.get_entities_without_property("material", volumes=volume_ids)
+            if mesh.are_there_volumes_in_geometry():
+                volume_ids = mesh.geometry_information.get("volumes")
+                volumes_without_material = properties.get_entities_without_property("material", volumes=volume_ids)
                 return not bool(len(volumes_without_material))
             else:
-                surface_ids = model.mesh.geometry_information.get("surfaces")
-                surfaces_without_material = model.properties.get_entities_without_property("material", surfaces=surface_ids)
+                surface_ids = mesh.geometry_information.get("surfaces")
+                surfaces_without_material = properties.get_entities_without_property("material", surfaces=surface_ids)
                 return not bool(len(surfaces_without_material))
 
         if property_name == "fluid":
-            if model.mesh.are_there_volumes_in_geometry():
-                volume_ids = model.mesh.geometry_information.get("volumes")
-                volumes_without_fluid = model.properties.get_entities_without_property("fluid", volumes=volume_ids)
+            if mesh.are_there_volumes_in_geometry():
+                volume_ids = mesh.geometry_information.get("volumes")
+                volumes_without_fluid = properties.get_entities_without_property("fluid", volumes=volume_ids)
                 return not bool(len(volumes_without_fluid))
             # else:
-            #     surface_ids = model.mesh.geometry_information.get("surfaces")
-            #     surfaces_without_fluid = model.properties.get_entities_without_property("fluid", surfaces=surface_ids)
+            #     surface_ids = mesh.geometry_information.get("surfaces")
+            #     surfaces_without_fluid = properties.get_entities_without_property("fluid", surfaces=surface_ids)
             #     return not bool(len(surfaces_without_fluid))
 
         # test for mesh. Not ideal, but it works. Since the mesh config is not part of the properties, the necessary check is performed here
         if property_name == "mesh_setup":
-            mesh = model.mesh
-            collapsed = (mesh.collapsed_3d_elements or mesh.collapsed_2d_elements or mesh.collapsed_1d_elements)
-            if collapsed:
+            disconnected_nodes = bool(mesh.disconnected_nodes)
+            collapsed_elements = bool(mesh.collapsed_3d_elements or mesh.collapsed_2d_elements or mesh.collapsed_1d_elements)
+            if collapsed_elements or disconnected_nodes:
                 return False
             return model.mesh_setup is not None
 
         # verify if there are surface thickness in all surfaces before changing the icon
         if property_name == "surface_thickness":
-            if model.mesh is not None:
+            if mesh is not None:
                 st_check = model.is_surface_thickness_properly_applied_in_model()
                 if isinstance(st_check, list) and st_check:
                     if st_check:
@@ -235,7 +236,7 @@ class ModelSetupItems(CommonMenuItems):
             for key in property_dict.keys():
                 if key[0] == property_name:
                     if property_name == "degrees_of_freedom_decoupling":
-                        pp_data = model.properties._get_property("perforated_plate_model", surface=key[1])
+                        pp_data = properties._get_property("perforated_plate_model", surface=key[1])
                         if isinstance(pp_data, dict):
                             continue
 

--- a/vibra/interface/menus/results_viewer_items.py
+++ b/vibra/interface/menus/results_viewer_items.py
@@ -149,7 +149,7 @@ class ResultsViewerItems(CommonMenuItems):
         elif analysis_id in [AnalysisID.ACOUSTIC_HARMONIC, AnalysisID.ACOUSTIC_MODAL]:
             self.update_acoustic_analysis_visibility_items()
         
-        elif analysis_id in [AnalysisID.COUPLED_HARMONIC]:    
+        elif analysis_id == AnalysisID.COUPLED_HARMONIC:    
             self.update_coupled_analysis_visibility_items()
 
         if analysis_id in [AnalysisID.STRUCTURAL_HARMONIC]:

--- a/vibra/interface/menus/results_viewer_widget.py
+++ b/vibra/interface/menus/results_viewer_widget.py
@@ -24,9 +24,15 @@ class ResultsViewerWidget(LeftMenuWidget_UI):
 
     def _reset(self):
         self.current_widget = None
-    
+
     def hide_bottom_widget(self):
         self.bottom_widget.hide()
+
+    def clear_treeWidgets_of_frequencies(self):
+        self.plot_structural_modal.treeWidget_frequencies.clear()
+        self.plot_structural_harmonic.treeWidget_frequencies.clear()
+        self.plot_acoustic_modal.treeWidget_frequencies.clear()
+        self.plot_acoustic_harmonic.treeWidget_frequencies.clear()
 
     def _define_qt_variables(self):
         self.main_frame = QFrame()

--- a/vibra/interface/mesh/mesher_setup_inputs.py
+++ b/vibra/interface/mesh/mesher_setup_inputs.py
@@ -439,20 +439,29 @@ class MesherSetupInputs(MesherSetupInputs_UI):
 
         LoadingWindow(generate_function).run()
 
-        collapsed = (self.mesh.collapsed_3d_elements or self.mesh.collapsed_2d_elements or self.mesh.collapsed_1d_elements)
+        disconnected_nodes = self.mesh.disconnected_nodes
+        collapsed_elements = (self.mesh.collapsed_3d_elements or self.mesh.collapsed_2d_elements or self.mesh.collapsed_1d_elements)
 
-        if collapsed:
+        run_analysis_button = app().main_window.analysis_toolbar.pushButton_run_analysis
+        run_analysis_button.setDisabled(bool(collapsed_elements) or bool(self.mesh.disconnected_nodes))
+
+        if disconnected_nodes:
+            title = "The generated mesh contains disconnected nodes"
+            message = "Disconnected nodes: " + ", ".join(str(int(node_id)) for node_id in disconnected_nodes) + "."
+            PrintMessageInput([error_title, title, message])
+
+        if collapsed_elements:
             title = "The generated mesh contains collapsed elements"
 
             message = ""
             if self.mesh.collapsed_3d_elements:
-                message += "Collapsed 3d elements: " + ", ".join(str(i) for i in self.mesh.collapsed_3d_elements) + ".\n\n"
+                message += "Collapsed 3d elements: " + ", ".join(str(elem_id) for elem_id in self.mesh.collapsed_3d_elements) + ".\n\n"
 
             if self.mesh.collapsed_2d_elements:
-                message += "Collapsed 2d elements: " + ", ".join(str(i) for i in self.mesh.collapsed_2d_elements) + ".\n\n"
+                message += "Collapsed 2d elements: " + ", ".join(str(elem_id) for elem_id in self.mesh.collapsed_2d_elements) + ".\n\n"
 
             if self.mesh.collapsed_1d_elements:
-                message += "Collapsed 1d elements: " + ", ".join(str(i) for i in self.mesh.collapsed_1d_elements) + "."
+                message += "Collapsed 1d elements: " + ", ".join(str(elem_id) for elem_id in self.mesh.collapsed_1d_elements) + "."
 
             PrintMessageInput([error_title, title, message])
 
@@ -475,6 +484,8 @@ class MesherSetupInputs(MesherSetupInputs_UI):
 
         LoadingWindow(self.actions_to_finalize).run()
         self.complete = True
+
+        app().main_window.set_mesh_selection(nodes=self.mesh.disconnected_nodes)
 
     def process_degress_of_freedom_if_necessary(self):
         if not app().project.model.properties.is_the_surface_property_present_in_the_model(

--- a/vibra/interface/user_input/input_ui.py
+++ b/vibra/interface/user_input/input_ui.py
@@ -183,11 +183,11 @@ class InputUi:
             return self.process_input(PlotStructuralModeShapeInputs)     
 
     def plot_displacement_field(self):
-        if self.project.analysis_id in [AnalysisID.STRUCTURAL_HARMONIC]:
+        if self.project.analysis_id == AnalysisID.STRUCTURAL_HARMONIC:
             return self.process_input(PlotDisplacementFieldInputs)
 
     def plot_structural_frequency_response(self):
-        if self.project.analysis_id in [AnalysisID.STRUCTURAL_HARMONIC]:
+        if self.project.analysis_id == AnalysisID.STRUCTURAL_HARMONIC:
             return self.process_input(PlotStructuralFrequencyResponseInputs)
 
     def plot_reaction_frequency_response(self):

--- a/vibra/interface/viewer_3d/render_widgets/results_render_widget.py
+++ b/vibra/interface/viewer_3d/render_widgets/results_render_widget.py
@@ -476,13 +476,16 @@ class ResultsRenderWidget(AnimatedRenderWidget):
         if  self.frequency_index is None and self.mode_index is None:
             return
 
-        if analysis_id in [AnalysisID.STRUCTURAL_HARMONIC, AnalysisID.ACOUSTIC_HARMONIC]:
+        if analysis_id in [
+            AnalysisID.STRUCTURAL_HARMONIC, 
+            AnalysisID.ACOUSTIC_HARMONIC
+            ]:
             text += analysis_info_text(self.frequency_index + 1)
 
         if analysis_id in [
             AnalysisID.STRUCTURAL_MODAL,
             AnalysisID.ACOUSTIC_MODAL,
-        ]:
+            ]:
             text += analysis_info_text(self.mode_index)
 
         self.set_info_text(text)

--- a/vibra/project_files/project.py
+++ b/vibra/project_files/project.py
@@ -15,10 +15,10 @@ from vibra.interface.process_analysis import ProcessAnalysis
 from vibra.interface.model_inputs.general.mesher_setup_inputs import MesherSetupInputs
 from vibra.interface.loading_window import LoadingWindow
 
+from vibra.project_files.project_file import ProjectFile
+
 import logging
 from time import sleep, time
-
-from vibra.project_files.project_file import ProjectFile
 
 
 class Project(QObject):
@@ -50,7 +50,6 @@ class Project(QObject):
 
         def disable_resume_callback():
             self.can_resume_solution = False
-
 
         self.model = Model(disable_resume_callback)
         self.acoustic_assembler = AcousticAssembler(self.model)
@@ -243,7 +242,9 @@ class Project(QObject):
             return
 
         t0 = time()
-        self.acoustic_harmonic_solver.solve_direct(is_resume=is_resume)
+        if self.acoustic_harmonic_solver.solve_direct(is_resume=is_resume):
+            return
+
         dt = time() - t0
         print(f"Elapsed time to solve harmonic analysis: {dt : .6f} [s]")
 
@@ -284,7 +285,7 @@ class Project(QObject):
         checker = AnalysisRequirementsChecker()
         interrupt_function = app().project.model.toggle_processing_callback
 
-        if analysis_id in [AnalysisID.STRUCTURAL_HARMONIC]:
+        if analysis_id == AnalysisID.STRUCTURAL_HARMONIC:
             if checker.check_structural_harmonic_analysis():
                 return True
 
@@ -302,6 +303,7 @@ class Project(QObject):
         elif analysis_id == AnalysisID.ACOUSTIC_HARMONIC:
             if checker.check_acoustic_harmonic_analysis():
                 return True
+
             LoadingWindow(
                 analysis.process_acoustic_harmonic_analysis,
                 interrupt_function,    
@@ -336,7 +338,7 @@ class Project(QObject):
 
         analysis_id = analysis_setup.get("analysis_id", AnalysisID.NO_ANALYSIS)
 
-        if analysis_id in [AnalysisID.STRUCTURAL_HARMONIC]:
+        if analysis_id == AnalysisID.STRUCTURAL_HARMONIC:
             if self.structural_harmonic_solver is None:
                 return
 
@@ -392,7 +394,7 @@ class Project(QObject):
         if analysis_id in [AnalysisID.ACOUSTIC_HARMONIC, AnalysisID.ACOUSTIC_MODAL]:
             physical_domain = "acoustic"
 
-        elif analysis_id in [AnalysisID.COUPLED_HARMONIC]:
+        elif analysis_id == AnalysisID.COUPLED_HARMONIC:
             physical_domain = "coupled"
 
         else:
@@ -416,16 +418,22 @@ class Project(QObject):
             if analysis_id != current_analysis_id:
                 return False
 
-        if analysis_id in [AnalysisID.ACOUSTIC_HARMONIC, AnalysisID.STRUCTURAL_HARMONIC, AnalysisID.COUPLED_HARMONIC]:
+        if analysis_id in [
+            AnalysisID.ACOUSTIC_HARMONIC, 
+            AnalysisID.STRUCTURAL_HARMONIC, 
+            AnalysisID.COUPLED_HARMONIC
+            ]:
+
             for key in ["f_min", "f_max", "f_step"]:
                 if key not in analysis_setup.keys():
                     return False
             return True
 
         elif analysis_id in [
-                             AnalysisID.ACOUSTIC_MODAL, 
-                             AnalysisID.STRUCTURAL_MODAL
-                             ]:
+            AnalysisID.ACOUSTIC_MODAL, 
+            AnalysisID.STRUCTURAL_MODAL
+            ]:
+
             for key in ["modes_number", "sigma_factor"]:
                 if key not in analysis_setup.keys():
                     return False


### PR DESCRIPTION
This pull request fixes some issues found after resolving two consecutive analyses if the last one is interrupted. The proposed solution consists of resetting all partial solutions and disabling the results workspace until all solution steps have been solved. I also took the opportunity to include a mesh-related criterion to avoid singularities while solving models whose meshes contain disconnected nodes.