### PR TITLE
Refactor: Replace raw tab indexes with Enums to improve readability

### DIFF
--- a/vibra/interface/model_inputs/acoustic/definitions/enums.py
+++ b/vibra/interface/model_inputs/acoustic/definitions/enums.py
@@ -7,6 +7,7 @@ class StandardTabType(IntEnum):
 
 class SetupTabType(IntEnum): 
     SETUP = 0
+    LIST = 1
 
 class AttributionBodiesType(IntEnum):
     ALL_BODIES = 0

--- a/vibra/interface/model_inputs/acoustic/definitions/enums.py
+++ b/vibra/interface/model_inputs/acoustic/definitions/enums.py
@@ -7,3 +7,7 @@ class StandardTabType(IntEnum):
 
 class SetupTabType(IntEnum): 
     SETUP = 0
+
+class AttributionBodiesType(IntEnum):
+    ALL_BODIES = 0
+    SELECTED_BODIES = 1

--- a/vibra/interface/model_inputs/acoustic/definitions/enums.py
+++ b/vibra/interface/model_inputs/acoustic/definitions/enums.py
@@ -1,8 +1,9 @@
 from enum import IntEnum
 
-class ConstTabularTabType(IntEnum):
+class StandardTabType(IntEnum):
     CONSTANT_DATA = 0
     TABULAR_DATA = 1
+    LIST = 2
 
 class SetupTabType(IntEnum): 
     SETUP = 0

--- a/vibra/interface/model_inputs/acoustic/definitions/enums.py
+++ b/vibra/interface/model_inputs/acoustic/definitions/enums.py
@@ -12,3 +12,9 @@ class SetupTabType(IntEnum):
 class AttributionBodiesType(IntEnum):
     ALL_BODIES = 0
     SELECTED_BODIES = 1
+
+class PlotTypesTab(IntEnum):
+    FLUID_DENSITY = 0
+    SPEED_OF_SOUND = 1
+    SURFACE_IMPEDANCE = 2
+    ABSORPTION_COEFFICIENT = 3

--- a/vibra/interface/model_inputs/acoustic/definitions/enums.py
+++ b/vibra/interface/model_inputs/acoustic/definitions/enums.py
@@ -18,3 +18,53 @@ class PlotTypesTab(IntEnum):
     SPEED_OF_SOUND = 1
     SURFACE_IMPEDANCE = 2
     ABSORPTION_COEFFICIENT = 3
+
+# Enums used by ReciprocatingCompressorInputs
+
+class RCTabTypes(IntEnum):
+    SETUP = SetupTabType.SETUP
+    ADVANCED_OPTIONS = 1
+    LIST = 2
+
+class ConnectionTypeComboBox(IntEnum):
+    SUCTION = 0
+    DISCHARGE = 1
+
+class CompressionStageComboBox(IntEnum):
+    FIRST_STAGE = 0
+    SECOND_STAGE = 1
+    THIRD_STAGE = 3
+
+class ActingHeadComboBox(IntEnum):
+    HEAD_END = 0
+    CRANK_END = 1
+    BOTH_ENDS = 2
+
+class FluidDataComboBox(IntEnum):
+    REF_PROP = 0
+    USER_DEFINED = 1
+
+class PressureUnitComboBox(IntEnum):
+    KGF_CM2_A = 0
+    BAR_A = 1
+    KPA_A = 2
+    PA_A = 3
+    KGF_CM2_G = 4
+    BAR_G = 5
+    KPA_G = 6
+    PA_G = 7
+
+class TemperatureUnitComboBox(IntEnum):
+    KELVIN = 0
+    CELSIUS = 1
+
+class OutputDataComboBox(IntEnum):
+    SURFACE_VELOCITY = 0
+    FLOW_RATE = 1
+
+class InitialFrequencyComboBox(IntEnum):
+    _0_DOT_1_HZ = 0
+    _0_DOT_2_HZ = 1
+    _0_DOT_5_HZ = 2
+    _1_DOT_0_HZ = 3
+    _2_DOT_0_HZ = 4

--- a/vibra/interface/model_inputs/acoustic/definitions/enums.py
+++ b/vibra/interface/model_inputs/acoustic/definitions/enums.py
@@ -1,0 +1,8 @@
+from enum import IntEnum
+
+class ConstTabularTabType(IntEnum):
+    CONSTANT_DATA = 0
+    TABULAR_DATA = 1
+
+class SetupTabType(IntEnum): 
+    SETUP = 0

--- a/vibra/interface/model_inputs/acoustic/definitions/enums.py
+++ b/vibra/interface/model_inputs/acoustic/definitions/enums.py
@@ -57,14 +57,3 @@ class PressureUnitComboBox(IntEnum):
 class TemperatureUnitComboBox(IntEnum):
     KELVIN = 0
     CELSIUS = 1
-
-class OutputDataComboBox(IntEnum):
-    SURFACE_VELOCITY = 0
-    FLOW_RATE = 1
-
-class InitialFrequencyComboBox(IntEnum):
-    _0_DOT_1_HZ = 0
-    _0_DOT_2_HZ = 1
-    _0_DOT_5_HZ = 2
-    _1_DOT_0_HZ = 3
-    _2_DOT_0_HZ = 4

--- a/vibra/interface/model_inputs/acoustic/dissipation_models/porous_material_model_inputs.py
+++ b/vibra/interface/model_inputs/acoustic/dissipation_models/porous_material_model_inputs.py
@@ -13,6 +13,7 @@ from vibra.interface.model_inputs.acoustic.dissipation_models.jca_data import JC
 from vibra.interface.general.get_user_confirmation_input import GetUserConfirmationInput
 from vibra.interface.general.print_message_input import PrintMessageInput
 from vibra.interface.plots.general.frequency_response_plotter import FrequencyResponsePlotter
+from vibra.interface.model_inputs.acoustic.definitions.enums import AttributionBodiesType
 
 from vibra.engine.properties.fluid import Fluid
 from vibra.engine.dissipation_models.porous_materials_models import PorousMaterialModels
@@ -32,6 +33,18 @@ class PMModels(IntEnum):
     DELANY_BAZLEY_MIKI = 1
     JCA = 2
     JCAL = 3
+    EDIT = 4
+    LIST = 5
+
+class PMEditModelsTab(IntEnum):
+    DB_DBM = 0
+    JCA_JCAL = 1
+
+class PlotTypesTab(IntEnum):
+    FLUID_DENSITY = 0
+    SPEED_OF_SOUND = 1
+    SURFACE_IMPEDANCE = 2
+    ABSORPTION_COEFFICIENT = 3
 
 
 class PorousMaterialModelInputs(PorousMaterialModelInputs_UI):
@@ -124,7 +137,7 @@ class PorousMaterialModelInputs(PorousMaterialModelInputs_UI):
         app().main_window.update_symbols()
     
     def geometry_selection_callback(self):
-        pm_tabs = self.tabWidget_main.currentIndex() <= 3
+        pm_tabs = self.tabWidget_main.currentIndex() <= PMModels.JCAL
 
         if not pm_tabs:
             return
@@ -133,8 +146,8 @@ class PorousMaterialModelInputs(PorousMaterialModelInputs_UI):
 
         if volumes:
 
-            if self.comboBox_attribution_type.currentIndex() == 0:
-                self.comboBox_attribution_type.setCurrentIndex(1)
+            if self.comboBox_attribution_type.currentIndex() == AttributionBodiesType.ALL_BODIES:
+                self.comboBox_attribution_type.setCurrentIndex(AttributionBodiesType.SELECTED_BODIES)
                 # return
 
             text = ", ".join([str(i) for i in volumes])
@@ -154,7 +167,7 @@ class PorousMaterialModelInputs(PorousMaterialModelInputs_UI):
 
         if pm_model == "Delany-Bazley":
 
-            self.tabWidget_main.setCurrentIndex(0)
+            self.tabWidget_main.setCurrentIndex(PMModels.DELANY_BAZLEY)
             self.doubleSpinBox_C1_DB.setValue(pm_data["C1"])
             self.doubleSpinBox_C2_DB.setValue(pm_data["C2"])
             self.doubleSpinBox_C3_DB.setValue(pm_data["C3"])
@@ -167,7 +180,7 @@ class PorousMaterialModelInputs(PorousMaterialModelInputs_UI):
 
         elif pm_model == "Delany-Bazley-Miki":
 
-            self.tabWidget_main.setCurrentIndex(1)
+            self.tabWidget_main.setCurrentIndex(PMModels.DELANY_BAZLEY_MIKI)
             self.doubleSpinBox_C1_DBM.setValue(pm_data["C1"])
             self.doubleSpinBox_C2_DBM.setValue(pm_data["C2"])
             self.doubleSpinBox_C3_DBM.setValue(pm_data["C3"])
@@ -180,7 +193,7 @@ class PorousMaterialModelInputs(PorousMaterialModelInputs_UI):
 
         elif pm_model in ["Jhonson-Champoux-Allard", ""]:
 
-            self.tabWidget_main.setCurrentIndex(2)
+            self.tabWidget_main.setCurrentIndex(PMModels.JCA)
             self.doubleSpinBox_porosity_JCA.setValue(pm_data["porosity"])
             self.doubleSpinBox_tortuosity_JCA.setValue(pm_data["tortuosity"])
             self.lineEdit_thermal_characteristic_length_JCA.setText(str(pm_data["thermal_characteristic_length"]))
@@ -189,7 +202,7 @@ class PorousMaterialModelInputs(PorousMaterialModelInputs_UI):
 
         elif pm_model == "Jhonson-Champoux-Allard-Lafarge":
 
-            self.tabWidget_main.setCurrentIndex(3)
+            self.tabWidget_main.setCurrentIndex(PMModels.JCAL)
             self.doubleSpinBox_porosity_JCAL.setValue(pm_data["porosity"])
             self.doubleSpinBox_tortuosity_JCAL.setValue(pm_data["tortuosity"])
             self.lineEdit_thermal_characteristic_length_JCAL.setText(str(pm_data["thermal_characteristic_length"]))
@@ -206,7 +219,7 @@ class PorousMaterialModelInputs(PorousMaterialModelInputs_UI):
         self.plot_type_callback()
 
     def plot_type_callback(self):
-        if self.comboBox_plot_type.currentIndex() < 2:
+        if self.comboBox_plot_type.currentIndex() < PlotTypesTab.SURFACE_IMPEDANCE:
             self.doubleSpinBox_porous_material_depth.setDisabled(True)
         else:
             self.doubleSpinBox_porous_material_depth.setDisabled(False)
@@ -231,7 +244,7 @@ class PorousMaterialModelInputs(PorousMaterialModelInputs_UI):
         self.actions_to_finalize()
 
         if len(self.map_model_id_to_model) > 0:
-            self.tabWidget_main.setCurrentIndex(5)
+            self.tabWidget_main.setCurrentIndex(PMModels.LIST)
 
     def reset_callback(self):
 
@@ -265,8 +278,8 @@ class PorousMaterialModelInputs(PorousMaterialModelInputs_UI):
 
     def tab_event_porous_material_model(self):
         current_tab = self.tabWidget_main.currentIndex()
-        edit_or_list_tabs = [4, 5]
-        pm_tab = current_tab <= 3
+        edit_or_list_tabs = [PMModels.EDIT, PMModels.LIST]
+        pm_tab = current_tab <= PMModels.JCAL
 
         if self.last_tab in edit_or_list_tabs or current_tab in edit_or_list_tabs:
             app().main_window.clear_selection()
@@ -280,7 +293,7 @@ class PorousMaterialModelInputs(PorousMaterialModelInputs_UI):
         self.last_tab = current_tab
 
         if pm_tab:
-            if self.comboBox_attribution_type.currentIndex() == 0:
+            if self.comboBox_attribution_type.currentIndex() == AttributionBodiesType.ALL_BODIES:
                 return
 
             self.lineEdit_selection_id.setDisabled(False)
@@ -361,10 +374,11 @@ class PorousMaterialModelInputs(PorousMaterialModelInputs_UI):
                                                   
     def update_attribution_type(self):
         index = self.comboBox_attribution_type.currentIndex()
-        if index == 0:
+        if index == AttributionBodiesType.ALL_BODIES:
             self.lineEdit_selection_id.setText("All bodies")
             self.lineEdit_selection_id.setEnabled(False)
-        elif index == 1:
+
+        elif index == AttributionBodiesType.SELECTED_BODIES:
             self.lineEdit_selection_id.clear()
             self.lineEdit_selection_id.setEnabled(True)
         # self.comboBox_attribution_type.setCurrentIndex(index)
@@ -462,16 +476,16 @@ class PorousMaterialModelInputs(PorousMaterialModelInputs_UI):
                 jca_counter += 1
 
         if there_is_jca_model:
-            self.tabWidget_models.setTabVisible(1, True)
+            self.tabWidget_models.setTabVisible(PMEditModelsTab.JCA_JCAL, True)
         
         if there_is_delany_model:
-            self.tabWidget_models.setTabVisible(0, True)
-            self.tabWidget_models.setCurrentIndex(0)
+            self.tabWidget_models.setTabVisible(PMEditModelsTab.DB_DBM, True)
+            self.tabWidget_models.setCurrentIndex(PMEditModelsTab.DB_DBM)
 
         if there_is_jca_model or there_is_delany_model:
-            self.tabWidget_main.setTabVisible(4, True)
-            self.tabWidget_main.setTabVisible(5, True)
-            self.tabWidget_main.setCurrentIndex(4)
+            self.tabWidget_main.setTabVisible(PMModels.EDIT, True)
+            self.tabWidget_main.setTabVisible(PMModels.LIST, True)
+            self.tabWidget_main.setCurrentIndex(PMModels.EDIT)
         
         self.update_tableWidget_DBM_items()
         self.update_tableWidget_JCAL_items()
@@ -507,11 +521,11 @@ class PorousMaterialModelInputs(PorousMaterialModelInputs_UI):
         self.tableWidget_JCAL.setRowCount(7)
         self.tableWidget_JCAL.setColumnCount(jca_count)
 
-        self.tabWidget_models.setTabVisible(0, False)
-        self.tabWidget_models.setTabVisible(1, False)
+        self.tabWidget_models.setTabVisible(PMEditModelsTab.DB_DBM, False)
+        self.tabWidget_models.setTabVisible(PMEditModelsTab.JCA_JCAL, False)
 
-        self.tabWidget_main.setTabVisible(4, False)
-        self.tabWidget_main.setTabVisible(5, False)
+        self.tabWidget_main.setTabVisible(PMModels.EDIT, False)
+        self.tabWidget_main.setTabVisible(PMModels.LIST, False)
     
     def update_tableWidget_DBM_items(self):
         for i in range(self.tableWidget_DBM.rowCount()):
@@ -620,14 +634,14 @@ class PorousMaterialModelInputs(PorousMaterialModelInputs_UI):
             return
 
         attribute_type = self.comboBox_attribution_type.currentIndex()
-        if attribute_type in [0, 1]:
+        if attribute_type in [AttributionBodiesType.ALL_BODIES, AttributionBodiesType.SELECTED_BODIES]:
             
             volume_ids = list()
-            if attribute_type == 0:
+            if attribute_type == AttributionBodiesType.ALL_BODIES:
                 if "volumes" in self.mesh.geometry_information.keys():
                     volume_ids = self.mesh.geometry_information["volumes"]
 
-            elif attribute_type == 1:
+            elif attribute_type == AttributionBodiesType.SELECTED_BODIES:
 
                 input_ids = self.lineEdit_selection_id.text()
                 volume_ids, error_data = self.mesh.check_selected_ids(
@@ -775,12 +789,15 @@ class PorousMaterialModelInputs(PorousMaterialModelInputs_UI):
 
     def plot_data_callback(self):
         plot_key = self.comboBox_plot_type.currentIndex()
-        if plot_key == 0:
+        if plot_key == PlotTypesTab.FLUID_DENSITY:
             self.plot_effective_fluid_density()
-        elif plot_key == 1:
+
+        elif plot_key == PlotTypesTab.SPEED_OF_SOUND:
             self.plot_effective_speed_of_sound()
-        elif plot_key == 2:
+
+        elif plot_key == PlotTypesTab.SURFACE_IMPEDANCE:
             self.plot_surface_impedance()
+            
         else:
             self.plot_absorption_coefficient()
 

--- a/vibra/interface/model_inputs/acoustic/dissipation_models/porous_material_model_inputs.py
+++ b/vibra/interface/model_inputs/acoustic/dissipation_models/porous_material_model_inputs.py
@@ -28,7 +28,7 @@ window_title_1 = "Error"
 window_title_2 = "Warning"
 
 
-class PMModels(IntEnum):
+class TabType(IntEnum):
     DELANY_BAZLEY = 0
     DELANY_BAZLEY_MIKI = 1
     JCA = 2
@@ -130,7 +130,7 @@ class PorousMaterialModelInputs(PorousMaterialModelInputs_UI):
         app().main_window.update_symbols()
     
     def geometry_selection_callback(self):
-        pm_tabs = self.tabWidget_main.currentIndex() <= PMModels.JCAL
+        pm_tabs = self.tabWidget_main.currentIndex() <= TabType.JCAL
 
         if not pm_tabs:
             return
@@ -160,7 +160,7 @@ class PorousMaterialModelInputs(PorousMaterialModelInputs_UI):
 
         if pm_model == "Delany-Bazley":
 
-            self.tabWidget_main.setCurrentIndex(PMModels.DELANY_BAZLEY)
+            self.tabWidget_main.setCurrentIndex(TabType.DELANY_BAZLEY)
             self.doubleSpinBox_C1_DB.setValue(pm_data["C1"])
             self.doubleSpinBox_C2_DB.setValue(pm_data["C2"])
             self.doubleSpinBox_C3_DB.setValue(pm_data["C3"])
@@ -173,7 +173,7 @@ class PorousMaterialModelInputs(PorousMaterialModelInputs_UI):
 
         elif pm_model == "Delany-Bazley-Miki":
 
-            self.tabWidget_main.setCurrentIndex(PMModels.DELANY_BAZLEY_MIKI)
+            self.tabWidget_main.setCurrentIndex(TabType.DELANY_BAZLEY_MIKI)
             self.doubleSpinBox_C1_DBM.setValue(pm_data["C1"])
             self.doubleSpinBox_C2_DBM.setValue(pm_data["C2"])
             self.doubleSpinBox_C3_DBM.setValue(pm_data["C3"])
@@ -186,7 +186,7 @@ class PorousMaterialModelInputs(PorousMaterialModelInputs_UI):
 
         elif pm_model in ["Jhonson-Champoux-Allard", ""]:
 
-            self.tabWidget_main.setCurrentIndex(PMModels.JCA)
+            self.tabWidget_main.setCurrentIndex(TabType.JCA)
             self.doubleSpinBox_porosity_JCA.setValue(pm_data["porosity"])
             self.doubleSpinBox_tortuosity_JCA.setValue(pm_data["tortuosity"])
             self.lineEdit_thermal_characteristic_length_JCA.setText(str(pm_data["thermal_characteristic_length"]))
@@ -195,7 +195,7 @@ class PorousMaterialModelInputs(PorousMaterialModelInputs_UI):
 
         elif pm_model == "Jhonson-Champoux-Allard-Lafarge":
 
-            self.tabWidget_main.setCurrentIndex(PMModels.JCAL)
+            self.tabWidget_main.setCurrentIndex(TabType.JCAL)
             self.doubleSpinBox_porosity_JCAL.setValue(pm_data["porosity"])
             self.doubleSpinBox_tortuosity_JCAL.setValue(pm_data["tortuosity"])
             self.lineEdit_thermal_characteristic_length_JCAL.setText(str(pm_data["thermal_characteristic_length"]))
@@ -237,7 +237,7 @@ class PorousMaterialModelInputs(PorousMaterialModelInputs_UI):
         self.actions_to_finalize()
 
         if len(self.map_model_id_to_model) > 0:
-            self.tabWidget_main.setCurrentIndex(PMModels.LIST)
+            self.tabWidget_main.setCurrentIndex(TabType.LIST)
 
     def reset_callback(self):
 
@@ -271,8 +271,8 @@ class PorousMaterialModelInputs(PorousMaterialModelInputs_UI):
 
     def tab_event_porous_material_model(self):
         current_tab = self.tabWidget_main.currentIndex()
-        edit_or_list_tabs = [PMModels.EDIT, PMModels.LIST]
-        pm_tab = current_tab <= PMModels.JCAL
+        edit_or_list_tabs = [TabType.EDIT, TabType.LIST]
+        pm_tab = current_tab <= TabType.JCAL
 
         if self.last_tab in edit_or_list_tabs or current_tab in edit_or_list_tabs:
             app().main_window.clear_selection()
@@ -476,9 +476,9 @@ class PorousMaterialModelInputs(PorousMaterialModelInputs_UI):
             self.tabWidget_models.setCurrentIndex(PMEditModelsTab.DB_DBM)
 
         if there_is_jca_model or there_is_delany_model:
-            self.tabWidget_main.setTabVisible(PMModels.EDIT, True)
-            self.tabWidget_main.setTabVisible(PMModels.LIST, True)
-            self.tabWidget_main.setCurrentIndex(PMModels.EDIT)
+            self.tabWidget_main.setTabVisible(TabType.EDIT, True)
+            self.tabWidget_main.setTabVisible(TabType.LIST, True)
+            self.tabWidget_main.setCurrentIndex(TabType.EDIT)
         
         self.update_tableWidget_DBM_items()
         self.update_tableWidget_JCAL_items()
@@ -517,8 +517,8 @@ class PorousMaterialModelInputs(PorousMaterialModelInputs_UI):
         self.tabWidget_models.setTabVisible(PMEditModelsTab.DB_DBM, False)
         self.tabWidget_models.setTabVisible(PMEditModelsTab.JCA_JCAL, False)
 
-        self.tabWidget_main.setTabVisible(PMModels.EDIT, False)
-        self.tabWidget_main.setTabVisible(PMModels.LIST, False)
+        self.tabWidget_main.setTabVisible(TabType.EDIT, False)
+        self.tabWidget_main.setTabVisible(TabType.LIST, False)
     
     def update_tableWidget_DBM_items(self):
         for i in range(self.tableWidget_DBM.rowCount()):
@@ -615,13 +615,13 @@ class PorousMaterialModelInputs(PorousMaterialModelInputs_UI):
     def attribute_callback(self):
 
         index = self.tabWidget_main.currentIndex()
-        if index == PMModels.DELANY_BAZLEY:
+        if index == TabType.DELANY_BAZLEY:
             model_data = self.get_Delany_Bazley_model_data()
-        elif index == PMModels.DELANY_BAZLEY_MIKI:
+        elif index == TabType.DELANY_BAZLEY_MIKI:
             model_data = self.get_Delany_Bazley_Miki_model_data()
-        elif index == PMModels.JCA:
+        elif index == TabType.JCA:
             model_data = self.get_Jhonson_Champoux_Allard_model_data()
-        elif index == PMModels.JCAL:
+        elif index == TabType.JCAL:
             model_data = self.get_Jhonson_Champoux_Allard_Lafarge_model_data()
         else:
             return
@@ -746,19 +746,19 @@ class PorousMaterialModelInputs(PorousMaterialModelInputs_UI):
 
         tab_index = self.tabWidget_main.currentIndex()
 
-        if tab_index == PMModels.DELANY_BAZLEY:
+        if tab_index == TabType.DELANY_BAZLEY:
             pm_data = self.get_Delany_Bazley_model_data()
             rho_eff, C_eff = model.get_Delany_Bazley_Miki_effective_properties(omega, fluid, pm_data.get_data())
 
-        elif tab_index == PMModels.DELANY_BAZLEY_MIKI:
+        elif tab_index == TabType.DELANY_BAZLEY_MIKI:
             pm_data = self.get_Delany_Bazley_Miki_model_data()
             rho_eff, C_eff = model.get_Delany_Bazley_Miki_effective_properties(omega, fluid, pm_data.get_data())
 
-        elif tab_index == PMModels.JCA:
+        elif tab_index == TabType.JCA:
             pm_data = self.get_Jhonson_Champoux_Allard_model_data()
             rho_eff, C_eff = model.get_JCA_effective_properties(omega, fluid, pm_data.get_data())
 
-        elif tab_index == PMModels.JCAL:
+        elif tab_index == TabType.JCAL:
             pm_data = self.get_Jhonson_Champoux_Allard_Lafarge_model_data()
             rho_eff, C_eff = model.get_JCAL_effective_properties(omega, fluid, pm_data.get_data())
 
@@ -771,13 +771,13 @@ class PorousMaterialModelInputs(PorousMaterialModelInputs_UI):
 
     def get_porous_material_model(self):
         tab_index = self.tabWidget_main.currentIndex()
-        if tab_index == PMModels.DELANY_BAZLEY:
+        if tab_index == TabType.DELANY_BAZLEY:
             return "Delany-Bazley"
-        elif tab_index == PMModels.DELANY_BAZLEY_MIKI:
+        elif tab_index == TabType.DELANY_BAZLEY_MIKI:
             return "Delany-Bazley-Miki"
-        elif tab_index == PMModels.JCA:
+        elif tab_index == TabType.JCA:
             return "Jhonson-Champoux-Allard"
-        elif tab_index == PMModels.JCAL:
+        elif tab_index == TabType.JCAL:
             return "Jhonson-Champoux-Allard-Lafarge"
 
     def plot_data_callback(self):

--- a/vibra/interface/model_inputs/acoustic/dissipation_models/porous_material_model_inputs.py
+++ b/vibra/interface/model_inputs/acoustic/dissipation_models/porous_material_model_inputs.py
@@ -13,7 +13,7 @@ from vibra.interface.model_inputs.acoustic.dissipation_models.jca_data import JC
 from vibra.interface.general.get_user_confirmation_input import GetUserConfirmationInput
 from vibra.interface.general.print_message_input import PrintMessageInput
 from vibra.interface.plots.general.frequency_response_plotter import FrequencyResponsePlotter
-from vibra.interface.model_inputs.acoustic.definitions.enums import AttributionBodiesType
+from vibra.interface.model_inputs.acoustic.definitions.enums import AttributionBodiesType, PlotTypesTab
 
 from vibra.engine.properties.fluid import Fluid
 from vibra.engine.dissipation_models.porous_materials_models import PorousMaterialModels
@@ -39,13 +39,6 @@ class PMModels(IntEnum):
 class PMEditModelsTab(IntEnum):
     DB_DBM = 0
     JCA_JCAL = 1
-
-class PlotTypesTab(IntEnum):
-    FLUID_DENSITY = 0
-    SPEED_OF_SOUND = 1
-    SURFACE_IMPEDANCE = 2
-    ABSORPTION_COEFFICIENT = 3
-
 
 class PorousMaterialModelInputs(PorousMaterialModelInputs_UI):
     def __init__(self, *args, **kwargs):
@@ -797,7 +790,7 @@ class PorousMaterialModelInputs(PorousMaterialModelInputs_UI):
 
         elif plot_key == PlotTypesTab.SURFACE_IMPEDANCE:
             self.plot_surface_impedance()
-            
+
         else:
             self.plot_absorption_coefficient()
 

--- a/vibra/interface/model_inputs/acoustic/dissipation_models/proportional_damping_inputs.py
+++ b/vibra/interface/model_inputs/acoustic/dissipation_models/proportional_damping_inputs.py
@@ -6,6 +6,7 @@ from vibra import app
 from vibra.interface.ui_generated.model.setup.acoustic.dissipation_models.proportional_damping_inputs_ui import ProportionalDampingInputs_UI
 from vibra.interface.general.get_user_confirmation_input import GetUserConfirmationInput
 from vibra.interface.general.print_message_input import PrintMessageInput
+from vibra.interface.model_inputs.acoustic.definitions.enums import AttributionBodiesType, SetupTabType
 
 window_title_1 = "Error"
 window_title_2 = "Warning"
@@ -60,9 +61,9 @@ class ProportionalDampingInput(ProportionalDampingInputs_UI):
     def attribution_type_callback(self):
 
         index = self.comboBox_attribution_type.currentIndex()
-        if index == 0:
+        if index == AttributionBodiesType.ALL_BODIES:
             self.lineEdit_selection_id.setText("All bodies")
-        elif index == 1:
+        elif index == AttributionBodiesType.SELECTED_BODIES:
             self.lineEdit_selection_id.setText("")
 
         self.lineEdit_selection_id.setEnabled(bool(index))
@@ -75,8 +76,8 @@ class ProportionalDampingInput(ProportionalDampingInputs_UI):
 
             volume_ids = [int(vol_id) for vol_id in volumes]
 
-            if self.comboBox_attribution_type.currentIndex() == 0:
-                self.comboBox_attribution_type.setCurrentIndex(1)
+            if self.comboBox_attribution_type.currentIndex() == AttributionBodiesType.ALL_BODIES:
+                self.comboBox_attribution_type.setCurrentIndex(AttributionBodiesType.SELECTED_BODIES)
 
             text = ", ".join([str(i) for i in volume_ids])
             self.lineEdit_selection_id.setText(text)
@@ -147,11 +148,11 @@ class ProportionalDampingInput(ProportionalDampingInputs_UI):
         attribute_type = self.comboBox_attribution_type.currentIndex()
             
         volume_ids = list()
-        if attribute_type == 0:
+        if attribute_type == AttributionBodiesType.ALL_BODIES:
             if "volumes" in self.mesh.geometry_information.keys():
                 volume_ids = self.mesh.geometry_information["volumes"]
 
-        elif attribute_type == 1:
+        elif attribute_type == AttributionBodiesType.SELECTED_BODIES:
             input_ids = self.lineEdit_selection_id.text()
             volume_ids, error_data = self.mesh.check_selected_ids(
                                                                     input_ids, 
@@ -235,7 +236,7 @@ class ProportionalDampingInput(ProportionalDampingInputs_UI):
     def tab_event_callback(self):
         app().main_window.clear_selection()
 
-        list_tab = self.tabWidget_main.currentIndex() == 1
+        list_tab = self.tabWidget_main.currentIndex() == SetupTabType.LIST
 
         self.pushButton_confirm.setDisabled(list_tab)
         self.lineEdit_selection_id.setDisabled(list_tab)
@@ -303,11 +304,11 @@ class ProportionalDampingInput(ProportionalDampingInputs_UI):
     def update_tabs_visibility(self):
         for (property, _) in self.properties.volume_properties.keys():
             if property == "proportional_damping":
-                self.tabWidget_main.setTabVisible(1, True)
+                self.tabWidget_main.setTabVisible(SetupTabType.LIST, True)
                 return
 
-        self.tabWidget_main.setTabVisible(1, False)
-        self.tabWidget_main.setCurrentIndex(0)
+        self.tabWidget_main.setTabVisible(SetupTabType.LIST, False)
+        self.tabWidget_main.setCurrentIndex(SetupTabType.SETUP)
 
     def actions_to_finalize(self):
         app().main_window.update_info_text()

--- a/vibra/interface/model_inputs/acoustic/dissipation_models/proportional_damping_inputs.py
+++ b/vibra/interface/model_inputs/acoustic/dissipation_models/proportional_damping_inputs.py
@@ -70,7 +70,7 @@ class ProportionalDampingInput(ProportionalDampingInputs_UI):
         self.lineEdit_selection_id.setEnabled(bool(index))
 
     def geometry_selection_callback(self):
-        if self.tabWidget_main.currentIndex() == 1:
+        if self.tabWidget_main.currentIndex() == SetupTabType.LIST:
             self.verify_if_selected_volumes_are_in_tree_widget_proportional_damping()
             return
 

--- a/vibra/interface/model_inputs/acoustic/dissipation_models/viscous_thermal_loss_model_inputs.py
+++ b/vibra/interface/model_inputs/acoustic/dissipation_models/viscous_thermal_loss_model_inputs.py
@@ -13,15 +13,14 @@ from vibra.interface.general.print_message_input import PrintMessageInput
 from vibra.interface.plots.general.frequency_response_plotter import FrequencyResponsePlotter
 from vibra.interface.model_inputs.acoustic.dissipation_models.rectangular_duct_data import RectangularDuctData
 from vibra.interface.model_inputs.acoustic.dissipation_models.circular_duct_data import CircularDuctData
+from vibra.interface.model_inputs.acoustic.definitions.enums import AttributionBodiesType, PlotTypesTab
 
 import warnings
 import numpy as np
 from enum import IntEnum
 from collections import defaultdict
 
-
 error_title = "Error"
-
 
 class TabType(IntEnum):
     RECTANGULAR = 0
@@ -29,17 +28,14 @@ class TabType(IntEnum):
     EDIT = 2
     LIST = 3
 
-
-class AttributionType(IntEnum):
-    ALL_BODIES = 0
-    SELECTED_BODIES = 1
-
-
 class SectionType(IntEnum):
     RECTANGULAR = 0
     QUADRANGULAR = 1
     NARROW_SLIT = 2
 
+class FormulationModelTab(IntEnum):
+    STINSON_MODEL = 0
+    LRF_MODEL = 1
 
 class ViscousThermalLossModelInputs(ViscousThermalModelInputs_UI):
     def __init__(self, *args, **kwargs):
@@ -116,7 +112,7 @@ class ViscousThermalLossModelInputs(ViscousThermalModelInputs_UI):
         self.plot_type_callback()
 
     def plot_type_callback(self):
-        if self.comboBox_plot_type.currentIndex() < 2:
+        if self.comboBox_plot_type.currentIndex() < PlotTypesTab.SURFACE_IMPEDANCE:
             self.doubleSpinBox_evaluated_depth.setDisabled(True)
         else:
             self.doubleSpinBox_evaluated_depth.setDisabled(False)
@@ -124,7 +120,7 @@ class ViscousThermalLossModelInputs(ViscousThermalModelInputs_UI):
     def update_rectangular_duct_area(self):
         try:
             height = float(self.lineEdit_height_rectangular.text())
-            if self.comboBox_section_type.currentIndex() == 1:
+            if self.comboBox_section_type.currentIndex() == SectionType.QUADRANGULAR:
                 self.lineEdit_width_rectangular.setText(f"{round(height, 6)}")
             width = float(self.lineEdit_width_rectangular.text())
             area = width * height
@@ -210,7 +206,7 @@ class ViscousThermalLossModelInputs(ViscousThermalModelInputs_UI):
         self.last_tab = current_tab
 
         if current_tab == TabType.EDIT:
-            self.comboBox_attribution_type.setCurrentIndex(1)
+            self.comboBox_attribution_type.setCurrentIndex(AttributionBodiesType.SELECTED_BODIES)
             self.comboBox_attribution_type.setDisabled(True)
             self.lineEdit_selection_id.setDisabled(True)
             self.frame_fluid_info.setDisabled(True)
@@ -229,7 +225,7 @@ class ViscousThermalLossModelInputs(ViscousThermalModelInputs_UI):
             self.frame_plot_buttons.setDisabled(False)
 
             self.comboBox_attribution_type.setDisabled(False)
-            if self.comboBox_attribution_type.currentIndex() == 0:
+            if self.comboBox_attribution_type.currentIndex() == AttributionBodiesType.ALL_BODIES:
                 return
 
             self.lineEdit_selection_id.setDisabled(False)
@@ -268,9 +264,9 @@ class ViscousThermalLossModelInputs(ViscousThermalModelInputs_UI):
 
         section_index = self.comboBox_section_type.currentIndex()
 
-        if section_index in [1, 2]:
+        if section_index in [SectionType.QUADRANGULAR, SectionType.NARROW_SLIT]:
             self.lineEdit_width_rectangular.setDisabled(True)
-            if section_index == 2:
+            if section_index == SectionType.NARROW_SLIT:
                 self.spinBox_number_of_terms.setDisabled(True)
                 self.lineEdit_width_rectangular.setText("2*a >> 2*b")
             else:
@@ -288,10 +284,10 @@ class ViscousThermalLossModelInputs(ViscousThermalModelInputs_UI):
     def attribution_type_callback(self):
 
         attribution_type = self.comboBox_attribution_type.currentIndex()
-        if attribution_type == AttributionType.ALL_BODIES:
+        if attribution_type == AttributionBodiesType.ALL_BODIES:
             self.lineEdit_selection_id.setText("All bodies")
 
-        elif attribution_type == AttributionType.SELECTED_BODIES:
+        elif attribution_type == AttributionBodiesType.SELECTED_BODIES:
             volumes = app().main_window.selected_geometry_volumes
             if not volumes:
                 self.lineEdit_selection_id.setText("")
@@ -400,11 +396,11 @@ class ViscousThermalLossModelInputs(ViscousThermalModelInputs_UI):
         self.tableWidget_circular.setRowCount(4)
         self.tableWidget_circular.setColumnCount(circular_duct_counter)
 
-        self.tabWidget_main.setTabVisible(2, False)
-        self.tabWidget_main.setTabVisible(3, False)
+        self.tabWidget_main.setTabVisible(TabType.EDIT, False)
+        self.tabWidget_main.setTabVisible(TabType.LIST, False)
 
-        self.tabWidget_models.setTabVisible(0, False)
-        self.tabWidget_models.setTabVisible(1, False)
+        self.tabWidget_models.setTabVisible(TabType.RECTANGULAR, False)
+        self.tabWidget_models.setTabVisible(TabType.CIRCULAR, False)
     
     def update_tableWidget_rectangular_items(self):
         for i in range(self.tableWidget_rectangular.rowCount()):
@@ -485,15 +481,15 @@ class ViscousThermalLossModelInputs(ViscousThermalModelInputs_UI):
                 is_there_circular_model = True
             
             if is_there_rectangular_model or is_there_circular_model:
-                self.tabWidget_main.setTabVisible(2, True)
-                self.tabWidget_main.setTabVisible(3, True)
-                self.tabWidget_main.setCurrentIndex(2)
+                self.tabWidget_main.setTabVisible(TabType.EDIT, True)
+                self.tabWidget_main.setTabVisible(TabType.LIST, True)
+                self.tabWidget_main.setCurrentIndex(TabType.EDIT)
             
             if is_there_rectangular_model:
-                self.tabWidget_models.setTabVisible(0, True)
+                self.tabWidget_models.setTabVisible(TabType.RECTANGULAR, True)
             
             if is_there_circular_model:
-                self.tabWidget_models.setTabVisible(1, True)
+                self.tabWidget_models.setTabVisible(TabType.CIRCULAR, True)
 
     def load_info(self):
         self.map_existing_viscous_thermal_loss_models()
@@ -512,11 +508,11 @@ class ViscousThermalLossModelInputs(ViscousThermalModelInputs_UI):
         for key, _ in self.properties.volume_properties.items():
             property, _ = key
             if property == "viscous_thermal_model":
-                self.tabWidget_main.setTabVisible(2, True)
+                self.tabWidget_main.setTabVisible(TabType.EDIT, True)
                 return
 
-        self.tabWidget_main.setTabVisible(2, False)
-        self.tabWidget_main.setCurrentIndex(0)
+        self.tabWidget_main.setTabVisible(TabType.EDIT, False)
+        self.tabWidget_main.setCurrentIndex(TabType.RECTANGULAR)
 
     def geometry_selection_callback(self):
 
@@ -525,8 +521,8 @@ class ViscousThermalLossModelInputs(ViscousThermalModelInputs_UI):
         if volumes:
             text = ", ".join([str(i) for i in volumes])
             self.lineEdit_selection_id.setText(text)
-            if self.comboBox_attribution_type.currentIndex() != AttributionType.SELECTED_BODIES:
-                self.comboBox_attribution_type.setCurrentIndex(AttributionType.SELECTED_BODIES)
+            if self.comboBox_attribution_type.currentIndex() != AttributionBodiesType.SELECTED_BODIES:
+                self.comboBox_attribution_type.setCurrentIndex(AttributionBodiesType.SELECTED_BODIES)
 
     def generate_mesh(self):
         if not app().project.model.generated_mesh:
@@ -572,7 +568,7 @@ class ViscousThermalLossModelInputs(ViscousThermalModelInputs_UI):
             lineEdit.setFocus()
             return dict()
         
-        if self.comboBox_formulation.currentIndex() == 0:
+        if self.comboBox_formulation.currentIndex() == FormulationModelTab.STINSON_MODEL:
             formulation = "Stinson model"
         else:
             formulation = "LRF model"
@@ -593,9 +589,9 @@ class ViscousThermalLossModelInputs(ViscousThermalModelInputs_UI):
 
         assignment_type = self.comboBox_attribution_type.currentIndex()
 
-        if assignment_type in [AttributionType.ALL_BODIES, AttributionType.SELECTED_BODIES]:
+        if assignment_type in [AttributionBodiesType.ALL_BODIES, AttributionBodiesType.SELECTED_BODIES]:
             volume_ids = list()
-            if assignment_type == AttributionType.ALL_BODIES:
+            if assignment_type == AttributionBodiesType.ALL_BODIES:
                 self.models = list()
 
                 if "volumes" in self.mesh.geometry_information.keys():
@@ -722,15 +718,15 @@ class ViscousThermalLossModelInputs(ViscousThermalModelInputs_UI):
             tv_data = self.get_circular_duct_inputs()
 
         if tv_data:
-            if tab_index == 0:
-                if self.comboBox_section_type.currentIndex() in [0, 1]:
+            if tab_index == TabType.RECTANGULAR:
+                if self.comboBox_section_type.currentIndex() in [AttributionBodiesType.ALL_BODIES, AttributionBodiesType.SELECTED_BODIES]:
                     rho_eff, C_eff = model.get_rectangular_section_effective_properties(omega, fluid, tv_data)
 
                 else:
                     rho_eff, C_eff = model.get_narrow_slit_section_effective_properties(omega, fluid, tv_data)
 
-            elif tab_index == 1:
-                if self.comboBox_formulation.currentIndex() == 0:
+            elif tab_index == TabType.CIRCULAR:
+                if self.comboBox_formulation.currentIndex() == FormulationModelTab.STINSON_MODEL:
                     rho_eff, C_eff = model.get_circular_section_effective_properties_for_Stinson_model(omega, fluid, tv_data)
                 else:
                     rho_eff, C_eff = model.get_circular_section_effective_properties_for_LRF_model(omega, fluid, tv_data)
@@ -744,25 +740,25 @@ class ViscousThermalLossModelInputs(ViscousThermalModelInputs_UI):
     def get_viscous_thermal_loss_model(self):
         tab_index = self.tabWidget_main.currentIndex()
         
-        if tab_index == 0:
+        if tab_index == TabType.RECTANGULAR:
             section_index = self.comboBox_section_type.currentIndex()
-            if section_index == 0:
+            if section_index == SectionType.RECTANGULAR:
                 return "Rectangular duct"
-            elif section_index == 1:
+            elif section_index == SectionType.QUADRANGULAR:
                 return "Quadrangular duct"
             else:
                 return "Narrow slit duct"
 
-        elif tab_index == 1:
+        elif tab_index == TabType.CIRCULAR:
             return "Circular duct"
 
     def plot_data_callback(self):
         plot_key = self.comboBox_plot_type.currentIndex()
-        if plot_key == 0:
+        if plot_key == PlotTypesTab.FLUID_DENSITY:
             self.plot_effective_fluid_density()
-        elif plot_key == 1:
+        elif plot_key == PlotTypesTab.SPEED_OF_SOUND:
             self.plot_effective_speed_of_sound()
-        elif plot_key == 2:
+        elif plot_key == PlotTypesTab.SURFACE_IMPEDANCE:
             self.plot_surface_impedance()
         else:
             self.plot_absorption_coefficient()

--- a/vibra/interface/model_inputs/acoustic/excitations/acoustic_pressure_inputs.py
+++ b/vibra/interface/model_inputs/acoustic/excitations/acoustic_pressure_inputs.py
@@ -81,7 +81,7 @@ class AcousticPressureInputs(AcousticPressureInputs_UI):
             self.treeWidget_acoustic_pressure.headerItem().setTextAlignment(i, Qt.AlignCenter)
 
     def geometry_selection_callback(self):
-        if self.tabWidget_main.currentIndex() == 2:
+        if self.tabWidget_main.currentIndex() == StandardTabType.LIST:
             self.verify_if_selected_surfaces_are_in_tree_widget_acoustic_pressure()
             return
         

--- a/vibra/interface/model_inputs/acoustic/excitations/acoustic_pressure_inputs.py
+++ b/vibra/interface/model_inputs/acoustic/excitations/acoustic_pressure_inputs.py
@@ -8,6 +8,7 @@ from vibra.interface.model_inputs.data_filter.change_frequency_data_handler impo
 from vibra.interface.general.get_user_confirmation_input import GetUserConfirmationInput
 from vibra.interface.general.print_message_input import PrintMessageInput
 from vibra.interface.data_handler.data_importer import DataImporter
+from vibra.interface.model_inputs.acoustic.definitions.enums import StandardTabType
 
 import os
 import numpy as np
@@ -92,7 +93,7 @@ class AcousticPressureInputs(AcousticPressureInputs_UI):
 
     def load_property_data(self, surface_id: int):
 
-        if self.tabWidget_main.currentIndex() == 2:
+        if self.tabWidget_main.currentIndex() == StandardTabType.LIST:
             return
 
         data = self.model.properties._get_property("acoustic_pressure", surface=surface_id)
@@ -100,18 +101,18 @@ class AcousticPressureInputs(AcousticPressureInputs_UI):
         if isinstance(data, dict):
 
             if "table_paths" in data.keys():
-                self.tabWidget_main.setCurrentIndex(1)
+                self.tabWidget_main.setCurrentIndex(StandardTabType.TABULAR_DATA)
                 self.lineEdit_table_path.setText(data["table_paths"][0])
             else:
-                self.tabWidget_main.setCurrentIndex(0)
+                self.tabWidget_main.setCurrentIndex(StandardTabType.CONSTANT_DATA)
                 self.lineEdit_real_value.setText(str(data["real_values"][0]))
                 self.lineEdit_imag_value.setText(str(data["imag_values"][0]))
 
     def tab_event_callback(self):
         current_tab = self.tabWidget_main.currentIndex()
-        tab_list = current_tab == 2
+        tab_list = current_tab == StandardTabType.LIST
     
-        if self.last_tab == 2 or tab_list:
+        if self.last_tab == StandardTabType.LIST or tab_list:
             app().main_window.clear_selection()
 
             self.lineEdit_selection_id.clear()
@@ -125,9 +126,10 @@ class AcousticPressureInputs(AcousticPressureInputs_UI):
 
     def attribute_callback(self):
         tab_index = self.tabWidget_main.currentIndex()
-        if tab_index == 0:
+        if tab_index == StandardTabType.CONSTANT_DATA:
             self.check_constant_values()
-        elif tab_index == 1:
+
+        elif tab_index == StandardTabType.TABULAR_DATA:
             self.check_table_values()
 
     def check_complex_entries(self, lineEdit_real, lineEdit_imag):
@@ -457,7 +459,7 @@ class AcousticPressureInputs(AcousticPressureInputs_UI):
                 self.tabWidget_main.setTabVisible(2, True)
                 return
 
-        self.tabWidget_main.setCurrentIndex(0)    
+        self.tabWidget_main.setCurrentIndex(StandardTabType.CONSTANT_DATA)    
         self.tabWidget_main.setTabVisible(2, False)
 
     def on_click_item(self, item):

--- a/vibra/interface/model_inputs/acoustic/excitations/mass_source_inputs.py
+++ b/vibra/interface/model_inputs/acoustic/excitations/mass_source_inputs.py
@@ -8,6 +8,7 @@ from vibra.interface.ui_generated.model.setup.acoustic.mass_source_inputs_ui imp
 from vibra.interface.model_inputs.data_filter.change_frequency_data_handler import ChangeFrequencyDataRangeInput
 from vibra.interface.general.get_user_confirmation_input import GetUserConfirmationInput
 from vibra.interface.general.print_message_input import PrintMessageInput
+from vibra.interface.model_inputs.acoustic.definitions.enums import StandardTabType
 
 import numpy as np
 
@@ -21,6 +22,12 @@ class AssignmentType(IntEnum):
     LINES = 2
     SURFACES = 3
     VOLUMES = 4
+
+class MSTabType(IntEnum):
+    CONSTANT_DATA = StandardTabType.CONSTANT_DATA
+    TABULAR_DATA = StandardTabType.TABULAR_DATA
+    ADVANCED_SEARCH = 2
+    LIST = 3
 
 error_title = "Error"
 
@@ -104,7 +111,7 @@ class MassSourceInputs(MassSourceInputs_UI):
         points = app().main_window.selected_geometry_points
         nodes = app().main_window.selected_mesh_nodes
 
-        tab_list = self.tabWidget_main.currentIndex() == 3
+        tab_list = self.tabWidget_main.currentIndex() == MSTabType.LIST
 
         if tab_list:
             return
@@ -113,27 +120,27 @@ class MassSourceInputs(MassSourceInputs_UI):
         if volumes:
             text = ", ".join([str(i) for i in volumes])
             self.lineEdit_selection_id.setText(text)
-            self.comboBox_attribution_type.setCurrentIndex(4)
+            self.comboBox_attribution_type.setCurrentIndex(AssignmentType.VOLUMES)
 
         elif surfaces:
             text = ", ".join([str(i) for i in surfaces])
             self.lineEdit_selection_id.setText(text)
-            self.comboBox_attribution_type.setCurrentIndex(3)
+            self.comboBox_attribution_type.setCurrentIndex(AssignmentType.SURFACES)
 
         elif lines:
             text = ", ".join([str(i) for i in lines])
             self.lineEdit_selection_id.setText(text)
-            self.comboBox_attribution_type.setCurrentIndex(2)
+            self.comboBox_attribution_type.setCurrentIndex(AssignmentType.LINES)
 
         elif points:
             text = ", ".join([str(i) for i in points])
             self.lineEdit_selection_id.setText(text)
-            self.comboBox_attribution_type.setCurrentIndex(1)
+            self.comboBox_attribution_type.setCurrentIndex(AssignmentType.POINTS)
 
         elif nodes:
             text = ", ".join([str(i) for i in nodes])
             self.lineEdit_selection_id.setText(text)
-            self.comboBox_attribution_type.setCurrentIndex(0)
+            self.comboBox_attribution_type.setCurrentIndex(AssignmentType.NODES)
 
         if len(nodes) == 1:
             node_id = list(nodes)[0]
@@ -178,10 +185,10 @@ class MassSourceInputs(MassSourceInputs_UI):
         if isinstance(data, dict):
 
             if "table_paths" in data.keys():
-                self.tabWidget_main.setCurrentIndex(1)
+                self.tabWidget_main.setCurrentIndex(MSTabType.TABULAR_DATA)
                 self.lineEdit_table_path.setText(data["table_paths"][0])
             else:
-                self.tabWidget_main.setCurrentIndex(0)
+                self.tabWidget_main.setCurrentIndex(MSTabType.CONSTANT_DATA)
                 self.lineEdit_real_value.setText(str(data["real_values"][0]))
                 self.lineEdit_imag_value.setText(str(data["imag_values"][0]))
 
@@ -390,7 +397,7 @@ class MassSourceInputs(MassSourceInputs_UI):
 
     def compute_nearest_node_from_coordinate(self):
 
-        self.comboBox_attribution_type.setCurrentIndex(0)
+        self.comboBox_attribution_type.setCurrentIndex(AssignmentType.NODES)
 
         coord_x = self.check_inputs(self.lineEdit_point_coord_x, "Point coord. x")
         if coord_x is None:
@@ -420,9 +427,9 @@ class MassSourceInputs(MassSourceInputs_UI):
 
     def tab_event_callback(self):
         current_tab = self.tabWidget_main.currentIndex()
-        tab_list = current_tab == 3
+        tab_list = current_tab == MSTabType.LIST
 
-        if self.last_tab == 3 or tab_list:
+        if self.last_tab == MSTabType.LIST or tab_list:
             app().main_window.clear_selection()
             self.lineEdit_selection_id.clear()
 
@@ -442,9 +449,10 @@ class MassSourceInputs(MassSourceInputs_UI):
 
     def attribute_callback(self):
         tab_index = self.tabWidget_main.currentIndex()
-        if tab_index == 0:
+        if tab_index == MSTabType.CONSTANT_DATA:
             self.check_constant_values()
-        elif tab_index == 1:
+
+        elif tab_index == MSTabType.TABULAR_DATA:
             self.check_table_values()
 
     def check_selection_data(self, print_message: bool = True):
@@ -880,11 +888,11 @@ class MassSourceInputs(MassSourceInputs_UI):
                 if property != "mass_source":
                     continue
 
-                self.tabWidget_main.setTabVisible(3, True)
+                self.tabWidget_main.setTabVisible(MSTabType.LIST, True)
                 return
 
-        self.tabWidget_main.setCurrentIndex(0)    
-        self.tabWidget_main.setTabVisible(3, False)
+        self.tabWidget_main.setCurrentIndex(MSTabType.CONSTANT_DATA)    
+        self.tabWidget_main.setTabVisible(MSTabType.LIST, False)
 
     def on_click_item(self, item):
         selected_items, selection_text = self.get_selected_items_and_selection_text()

--- a/vibra/interface/model_inputs/acoustic/excitations/reciprocating_compressor_inputs.py
+++ b/vibra/interface/model_inputs/acoustic/excitations/reciprocating_compressor_inputs.py
@@ -162,7 +162,7 @@ class ReciprocatingCompressorInputs(ReciprocatingCompressorInputs_UI):
             self.lineEdit_molar_mass.setEnabled(True)
 
     def geometry_selection_callback(self):
-        if self.tabWidget_main.currentIndex() == 2:
+        if self.tabWidget_main.currentIndex() == RCTabTypes.LIST:
             self.verify_if_selected_surfaces_are_in_tree_widget_compressor_excitation()
             return
 

--- a/vibra/interface/model_inputs/acoustic/excitations/reciprocating_compressor_inputs.py
+++ b/vibra/interface/model_inputs/acoustic/excitations/reciprocating_compressor_inputs.py
@@ -11,6 +11,7 @@ from vibra.interface.model_inputs.general.mesher_setup_inputs import MesherSetup
 from vibra.interface.model_inputs.general.fluid.set_fluid_inputs import SetFluidInputs
 from vibra.interface.model_inputs.general.fluid.simplified_fluid_inputs import SimplifiedFluidInputs
 from vibra.interface.ui_generated.model.setup.acoustic.reciprocating_compressor_inputs_ui import ReciprocatingCompressorInputs_UI
+from vibra.interface.model_inputs.acoustic.definitions.enums import *
 
 from vibra.engine.properties.fluid import Fluid
 from vibra.model.machines.reciprocating_compressor_model import ReciprocatingCompressorModel
@@ -152,14 +153,11 @@ class ReciprocatingCompressorInputs(ReciprocatingCompressorInputs_UI):
 
         index = self.comboBox_fluid_data_source.currentIndex()
 
-        # RefProp
-        if index == 0:
+        if index == FluidDataComboBox.REF_PROP:
             self.lineEdit_isentropic_exponent.setDisabled(True)
             self.lineEdit_molar_mass.setDisabled(True)
 
-        # User-defined
-        elif index == 1:
-            self.lineEdit_isentropic_exponent.setEnabled(True)
+        elif index == FluidDataComboBox.USER_DEFINED:
             self.lineEdit_molar_mass.setEnabled(True)
 
     def geometry_selection_callback(self):
@@ -191,12 +189,12 @@ class ReciprocatingCompressorInputs(ReciprocatingCompressorInputs_UI):
 
     def tab_event_callback(self):
         current_tab = self.tabWidget_main.currentIndex()
-        tab_list = current_tab == 2
+        tab_list = current_tab == RCTabTypes.LIST
 
         self.pushButton_confirm.setDisabled(tab_list)
         self.lineEdit_selection_id.setDisabled(tab_list)
 
-        if self.last_tab == 2 or tab_list:
+        if self.last_tab == RCTabTypes.LIST or tab_list:
             app().main_window.clear_selection()
             self.lineEdit_selection_id.clear()
 
@@ -227,7 +225,7 @@ class ReciprocatingCompressorInputs(ReciprocatingCompressorInputs_UI):
         self.pushButton_plot_volume_head_end_angle.setEnabled(True)
         self.pushButton_plot_volume_crank_end_angle.setEnabled(True)
 
-        if self.comboBox_acting_head.currentIndex() == 0:
+        if self.comboBox_acting_head.currentIndex() == ActingHeadComboBox.HEAD_END:
             self.lineEdit_rod_diameter.setDisabled(True)
             self.lineEdit_clearance_crank_end.setDisabled(True)
             self.label_rod_diameter.setDisabled(True)
@@ -239,7 +237,7 @@ class ReciprocatingCompressorInputs(ReciprocatingCompressorInputs_UI):
             self.pushButton_plot_pressure_crank_end_angle.setDisabled(True)
             self.pushButton_plot_volume_crank_end_angle.setDisabled(True)
 
-        elif self.comboBox_acting_head.currentIndex() == 1:
+        elif self.comboBox_acting_head.currentIndex() == ActingHeadComboBox.CRANK_END:
             self.lineEdit_rod_diameter.setEnabled(True)
             self.lineEdit_clearance_head_end.setDisabled(True)
             self.lineEdit_clearance_crank_end.setEnabled(True)
@@ -255,7 +253,7 @@ class ReciprocatingCompressorInputs(ReciprocatingCompressorInputs_UI):
         if self.check_all_parameters(check_all_entries = check_all_entries):
             return None
 
-        if self.comboBox_connection_type.currentIndex() == 0:
+        if self.comboBox_connection_type.currentIndex() == ConnectionTypeComboBox.SUCTION:
             pressure = self.P_suction
             temperature = self.T_suction
 
@@ -295,7 +293,7 @@ class ReciprocatingCompressorInputs(ReciprocatingCompressorInputs_UI):
 
             self.fluid_dialog.close()
             if self.selected_fluid.name in self.fluid_dialog.fluid_widget.fluid_name_to_refprop_data.keys():
-                self.comboBox_fluid_data_source.setCurrentIndex(0)
+                self.comboBox_fluid_data_source.setCurrentIndex(FluidDataComboBox.REF_PROP)
 
             self.lineEdit_selected_fluid.setText(self.selected_fluid.name)
             self.lineEdit_isentropic_exponent.setText(f"{self.selected_fluid.isentropic_exponent : .6f}")
@@ -326,9 +324,9 @@ class ReciprocatingCompressorInputs(ReciprocatingCompressorInputs_UI):
         if "connection_type" in data.keys():
             connection_type = data["connection_type"]
             if connection_type == 'suction':
-                self.comboBox_connection_type.setCurrentIndex(0)
+                self.comboBox_connection_type.setCurrentIndex(ConnectionTypeComboBox.SUCTION)
             elif connection_type == 'discharge':
-                self.comboBox_connection_type.setCurrentIndex(1)
+                self.comboBox_connection_type.setCurrentIndex(ConnectionTypeComboBox.DISCHARGE)
 
         parameters = data["parameters"]
 
@@ -417,10 +415,10 @@ class ReciprocatingCompressorInputs(ReciprocatingCompressorInputs_UI):
             self.comboBox_frequency_resolution.setCurrentIndex(index)
 
     def reset_entries(self):
-        self.comboBox_acting_head.setCurrentIndex(0)
-        self.comboBox_stage.setCurrentIndex(0)
-        self.comboBox_pressure_units.setCurrentIndex(0)
-        self.comboBox_temperature_units.setCurrentIndex(1)
+        self.comboBox_acting_head.setCurrentIndex(ActingHeadComboBox.HEAD_END)
+        self.comboBox_stage.setCurrentIndex(CompressionStageComboBox.FIRST_STAGE)
+        self.comboBox_pressure_units.setCurrentIndex(PressureUnitComboBox.KGF_CM2_A)
+        self.comboBox_temperature_units.setCurrentIndex(TemperatureUnitComboBox.CELSIUS)
         self.doubleSpinBox_rotational_speed.setValue(360)
         self.lineEdit_bore_diameter.setText("")
         self.lineEdit_stroke.setText("")
@@ -719,11 +717,11 @@ class ReciprocatingCompressorInputs(ReciprocatingCompressorInputs_UI):
         try:
 
             suction_temperature = float(self.lineEdit_temperature_at_suction.text())
-            if self.comboBox_temperature_units.currentIndex() == 1:
+            if self.comboBox_temperature_units.currentIndex() == TemperatureUnitComboBox.CELSIUS:
                 suction_temperature += 273.15
 
             discharge_temperature = suction_temperature * (pressure_ratio**((gamma-1)/gamma))
-            if self.comboBox_temperature_units.currentIndex() == 1:
+            if self.comboBox_temperature_units.currentIndex() == TemperatureUnitComboBox.CELSIUS:
                 discharge_temperature -= 273.15
 
             self.lineEdit_temperature_at_discharge.setText(f"{discharge_temperature : .6f}")
@@ -745,7 +743,7 @@ class ReciprocatingCompressorInputs(ReciprocatingCompressorInputs_UI):
 
         self.process_aquisition_parameters()
 
-        if self.comboBox_connection_type.currentIndex() == 0:
+        if self.comboBox_connection_type.currentIndex() == ConnectionTypeComboBox.SUCTION:
             flow_label = "in_flow"
             connection_type = "suction"
         else:
@@ -963,11 +961,11 @@ class ReciprocatingCompressorInputs(ReciprocatingCompressorInputs_UI):
 
         for (property, *_) in self.properties.surface_properties.keys():
             if property == "reciprocating_compressor_excitation":
-                self.tabWidget_main.setTabVisible(2, True)
+                self.tabWidget_main.setTabVisible(RCTabTypes.LIST, True)
                 return
 
-        self.tabWidget_main.setTabVisible(2, False)
-        self.tabWidget_main.setCurrentIndex(0)
+        self.tabWidget_main.setTabVisible(RCTabTypes.LIST, False)
+        self.tabWidget_main.setCurrentIndex(RCTabTypes.SETUP)
 
     def spinBox_event_number_of_points(self):
         if self.aquisition_parameters_processed:

--- a/vibra/interface/model_inputs/acoustic/excitations/surface_velocity_inputs.py
+++ b/vibra/interface/model_inputs/acoustic/excitations/surface_velocity_inputs.py
@@ -95,7 +95,7 @@ class SurfaceVelocityInputs(SurfaceVelocityInputs_UI):
             self.treeWidget_surface_velocity.headerItem().setTextAlignment(i, Qt.AlignCenter)
 
     def geometry_selection_callback(self):
-        if self.tabWidget_main.currentIndex() == 2:
+        if self.tabWidget_main.currentIndex() == StandardTabType.LIST:
             self.verify_if_selected_surfaces_are_in_tree_widget_surface_velocity()
             return
         

--- a/vibra/interface/model_inputs/acoustic/excitations/surface_velocity_inputs.py
+++ b/vibra/interface/model_inputs/acoustic/excitations/surface_velocity_inputs.py
@@ -8,7 +8,7 @@ from vibra.interface.model_inputs.data_filter.change_frequency_data_handler impo
 from vibra.interface.general.get_user_confirmation_input import GetUserConfirmationInput
 from vibra.interface.general.print_message_input import PrintMessageInput
 from vibra.interface.data_handler.data_importer import DataImporter
-
+from vibra.interface.model_inputs.acoustic.definitions.enums import StandardTabType
 import numpy as np
 
 window_title_1 = "Error"
@@ -107,7 +107,7 @@ class SurfaceVelocityInputs(SurfaceVelocityInputs_UI):
 
     def load_property_data(self, surface_id: int):
 
-        if self.tabWidget_main.currentIndex() == 2:
+        if self.tabWidget_main.currentIndex() == StandardTabType.LIST:
             return
 
         data = self.properties._get_property("surface_velocity", surface=surface_id)
@@ -133,18 +133,18 @@ class SurfaceVelocityInputs(SurfaceVelocityInputs_UI):
                 self.radioButton_element_integration_table.setChecked(True)
 
             if "table_paths" in data.keys():
-                self.tabWidget_main.setCurrentIndex(1)
+                self.tabWidget_main.setCurrentIndex(StandardTabType.TABULAR_DATA)
                 self.lineEdit_table_path.setText(data["table_paths"][0])
             else:
-                self.tabWidget_main.setCurrentIndex(0)
+                self.tabWidget_main.setCurrentIndex(StandardTabType.CONSTANT_DATA)
                 self.lineEdit_real_value.setText(str(data["real_values"][0]))
                 self.lineEdit_imag_value.setText(str(data["imag_values"][0]))
 
     def tab_event_callback(self):
         current_tab = self.tabWidget_main.currentIndex()
-        tab_list = current_tab == 2
+        tab_list = current_tab == StandardTabType.LIST
 
-        if self.last_tab == 2 or tab_list:
+        if self.last_tab == StandardTabType.LIST or tab_list:
             app().main_window.clear_selection()
             self.lineEdit_selection_id.clear()
 
@@ -159,9 +159,10 @@ class SurfaceVelocityInputs(SurfaceVelocityInputs_UI):
 
     def attribute_callback(self):
         tab_index = self.tabWidget_main.currentIndex()
-        if tab_index == 0:
+        if tab_index == StandardTabType.CONSTANT_DATA:
             self.check_constant_values()
-        elif tab_index == 1:
+
+        elif tab_index == StandardTabType.TABULAR_DATA:
             self.check_table_values()
 
     def check_complex_entries(self, lineEdit_real, lineEdit_imag):
@@ -511,11 +512,11 @@ class SurfaceVelocityInputs(SurfaceVelocityInputs_UI):
         for key in self.properties.surface_properties.keys():
             property, *args = key
             if property == "surface_velocity":
-                self.tabWidget_main.setTabVisible(2, True)
+                self.tabWidget_main.setTabVisible(StandardTabType.LIST, True)
                 return
 
-        self.tabWidget_main.setCurrentIndex(0)    
-        self.tabWidget_main.setTabVisible(2, False)
+        self.tabWidget_main.setCurrentIndex(StandardTabType.CONSTANT_DATA)    
+        self.tabWidget_main.setTabVisible(StandardTabType.LIST, False)
 
     def on_click_item(self, item):
         surface_ids, selection_text = self.get_selected_surfaces_and_selection_text()

--- a/vibra/interface/model_inputs/acoustic/external_impedances/absorption_surface_inputs.py
+++ b/vibra/interface/model_inputs/acoustic/external_impedances/absorption_surface_inputs.py
@@ -130,7 +130,7 @@ class AbsorptionSurfaceInputs(AbsorptionSurfaceInputs_UI):
         self.lineEdit_selection_id.setToolTip("")
 
     def geometry_selection_callback(self):
-        if self.tabWidget_main.currentIndex() == 2:
+        if self.tabWidget_main.currentIndex() == StandardTabType.LIST:
             self.verify_if_selected_surfaces_are_in_tree_widget_absorption_surface()
             return
 

--- a/vibra/interface/model_inputs/acoustic/external_impedances/absorption_surface_inputs.py
+++ b/vibra/interface/model_inputs/acoustic/external_impedances/absorption_surface_inputs.py
@@ -8,7 +8,7 @@ from vibra.interface.general.get_user_confirmation_input import GetUserConfirmat
 from vibra.interface.general.print_message_input import PrintMessageInput
 from vibra.interface.model_inputs.data_filter.change_frequency_data_handler import ChangeFrequencyDataRangeInput
 from vibra.interface.ui_generated.model.setup.acoustic.absorption_surface_inputs_ui import AbsorptionSurfaceInputs_UI
-
+from vibra.interface.model_inputs.acoustic.definitions.enums import StandardTabType
 import numpy as np
 
 error_title = "Error"
@@ -73,9 +73,9 @@ class AbsorptionSurfaceInputs(AbsorptionSurfaceInputs_UI):
 
     def tab_event_callback(self):
         current_tab = self.tabWidget_main.currentIndex()
-        tab_list = current_tab == 2
+        tab_list = current_tab == StandardTabType.LIST
 
-        if self.last_tab == 2 or tab_list:
+        if self.last_tab == StandardTabType.LIST or tab_list:
             app().main_window.clear_selection()
             self.lineEdit_selection_id.clear()
 
@@ -136,12 +136,12 @@ class AbsorptionSurfaceInputs(AbsorptionSurfaceInputs_UI):
             return
 
         if "table_paths" in data.keys():
-            if self.tabWidget_main.currentIndex() != 2:
-                self.tabWidget_main.setCurrentIndex(1)
+            if self.tabWidget_main.currentIndex() != StandardTabType.LIST:
+                self.tabWidget_main.setCurrentIndex(StandardTabType.TABULAR_DATA)
             self.lineEdit_table_path.setText(data.get("table_paths")[0])
         else:
-            if self.tabWidget_main.currentIndex() != 2:
-                self.tabWidget_main.setCurrentIndex(0)
+            if self.tabWidget_main.currentIndex() != StandardTabType.LIST:
+                self.tabWidget_main.setCurrentIndex(StandardTabType.CONSTANT_DATA)
             self.lineEdit_real_value.setText(f"{data.get('real_values')[0]}")
 
     def load_model_info(self):
@@ -166,9 +166,10 @@ class AbsorptionSurfaceInputs(AbsorptionSurfaceInputs_UI):
 
     def attribute_callback(self):
         tab_index = self.tabWidget_main.currentIndex()
-        if tab_index == 0:
+        if tab_index == StandardTabType.CONSTANT_DATA:
             self.constant_data_assignment()
-        elif tab_index == 1:
+
+        elif tab_index == StandardTabType.TABULAR_DATA:
             self.tabular_data_assignment()
 
     def check_inputs(self, lineEdit: QLineEdit, label: str, zero_included: bool = True, only_positive: bool = True):
@@ -509,11 +510,11 @@ class AbsorptionSurfaceInputs(AbsorptionSurfaceInputs_UI):
         for key in self.properties.surface_properties.keys():
             property, *args = key
             if property == "absorption_surface":
-                self.tabWidget_main.setTabVisible(2, True)
+                self.tabWidget_main.setTabVisible(StandardTabType.LIST, True)
                 return
 
-        self.tabWidget_main.setCurrentIndex(0)
-        self.tabWidget_main.setTabVisible(2, False)
+        self.tabWidget_main.setCurrentIndex(StandardTabType.CONSTANT_DATA)
+        self.tabWidget_main.setTabVisible(StandardTabType.LIST, False)
 
     def keyPressEvent(self, event):
         if event.key() == Qt.Key_Enter or event.key() == Qt.Key_Return:

--- a/vibra/interface/model_inputs/acoustic/external_impedances/anechoic_termination_inputs.py
+++ b/vibra/interface/model_inputs/acoustic/external_impedances/anechoic_termination_inputs.py
@@ -93,7 +93,7 @@ class AnechoicTerminationInputs(AnechoicTerminationInputs_UI):
             self.pushButton_attribute.setEnabled(True)
 
     def geometry_selection_callback(self):
-        if self.tabWidget_main.currentIndex() == 1:
+        if self.tabWidget_main.currentIndex() == SetupTabType.LIST:
             self.verify_if_selected_surfaces_are_in_tree_widget_anechoic_termination()
             return
 

--- a/vibra/interface/model_inputs/acoustic/external_impedances/anechoic_termination_inputs.py
+++ b/vibra/interface/model_inputs/acoustic/external_impedances/anechoic_termination_inputs.py
@@ -8,6 +8,7 @@ from vibra import app
 from vibra.interface.ui_generated.model.setup.acoustic.anechoic_termination_inputs_ui import AnechoicTerminationInputs_UI
 from vibra.interface.general.get_user_confirmation_input import GetUserConfirmationInput
 from vibra.interface.general.print_message_input import PrintMessageInput
+from vibra.interface.model_inputs.acoustic.definitions.enums import SetupTabType
 
 window_title_1 = "Error"
 window_title_2 = "Warning"
@@ -83,7 +84,7 @@ class AnechoicTerminationInputs(AnechoicTerminationInputs_UI):
         self.treeWidget_anechoic_termination.clearSelection()
         self.pushButton_remove.setDisabled(True)
 
-        if self.tabWidget_main.currentIndex() == 1:
+        if self.tabWidget_main.currentIndex() == SetupTabType.LIST:
             self.lineEdit_selection_id.setDisabled(True)
             self.pushButton_attribute.setDisabled(True)
         else:
@@ -284,11 +285,11 @@ class AnechoicTerminationInputs(AnechoicTerminationInputs_UI):
             property, *args = key
             if property == "specific_impedance":
                 if "anechoic_termination" in data.keys():
-                    self.tabWidget_main.setTabVisible(1, True)
+                    self.tabWidget_main.setTabVisible(SetupTabType.LIST, True)
                     return
 
-        self.tabWidget_main.setCurrentIndex(0)
-        self.tabWidget_main.setTabVisible(1, False)
+        self.tabWidget_main.setCurrentIndex(SetupTabType.SETUP)
+        self.tabWidget_main.setTabVisible(SetupTabType.LIST, False)
 
     def on_click_item(self, item):
         surface_ids, selection_text = self.get_selected_surfaces_and_selection_text()
@@ -334,7 +335,7 @@ class AnechoicTerminationInputs(AnechoicTerminationInputs_UI):
 
     def keyPressEvent(self, event):
         if event.key() == Qt.Key_Enter or event.key() == Qt.Key_Return:
-            if self.tabWidget_main.currentIndex() == 0:
+            if self.tabWidget_main.currentIndex() == SetupTabType.SETUP:
                 self.attribute_callback()
         elif event.key() == Qt.Key_Delete:
             self.remove_callback()

--- a/vibra/interface/model_inputs/acoustic/external_impedances/specific_impedance_inputs.py
+++ b/vibra/interface/model_inputs/acoustic/external_impedances/specific_impedance_inputs.py
@@ -130,7 +130,7 @@ class SpecificImpedanceInputs(SpecificImpedanceInputs_UI):
         self.lineEdit_selection_id.setToolTip("")
 
     def geometry_selection_callback(self):
-        if self.tabWidget_main.currentIndex() == 2:
+        if self.tabWidget_main.currentIndex() == StandardTabType.LIST:
             self.verify_if_selected_surfaces_are_in_tree_widget_specific_impedance()
             return
         

--- a/vibra/interface/model_inputs/acoustic/external_impedances/specific_impedance_inputs.py
+++ b/vibra/interface/model_inputs/acoustic/external_impedances/specific_impedance_inputs.py
@@ -8,7 +8,7 @@ from vibra.interface.general.get_user_confirmation_input import GetUserConfirmat
 from vibra.interface.general.print_message_input import PrintMessageInput
 from vibra.interface.model_inputs.data_filter.change_frequency_data_handler import ChangeFrequencyDataRangeInput
 from vibra.interface.ui_generated.model.setup.acoustic.specific_impedance_inputs_ui import SpecificImpedanceInputs_UI
-
+from vibra.interface.model_inputs.acoustic.definitions.enums import StandardTabType
 import numpy as np
 
 error_title = "Error"
@@ -73,9 +73,9 @@ class SpecificImpedanceInputs(SpecificImpedanceInputs_UI):
 
     def tab_event_callback(self):
         current_tab = self.tabWidget_main.currentIndex()
-        tab_list = current_tab == 2
+        tab_list = current_tab == StandardTabType.LIST
 
-        if self.last_tab == 2 or tab_list:
+        if self.last_tab == StandardTabType.LIST or tab_list:
             app().main_window.clear_selection()
             self.lineEdit_selection_id.clear()
 
@@ -136,12 +136,12 @@ class SpecificImpedanceInputs(SpecificImpedanceInputs_UI):
             return
 
         if "table_paths" in data.keys():
-            if self.tabWidget_main.currentIndex() != 2:
-                self.tabWidget_main.setCurrentIndex(1)
+            if self.tabWidget_main.currentIndex() != StandardTabType.LIST:
+                self.tabWidget_main.setCurrentIndex(StandardTabType.TABULAR_DATA)
             self.lineEdit_table_path.setText(data.get("table_paths")[0])
         else:
-            if self.tabWidget_main.currentIndex() != 2:
-                self.tabWidget_main.setCurrentIndex(0)
+            if self.tabWidget_main.currentIndex() != StandardTabType.LIST:
+                self.tabWidget_main.setCurrentIndex(StandardTabType.CONSTANT_DATA)
             self.lineEdit_real_value.setText(f"{data.get('real_values')[0]}")
 
     def load_model_info(self):
@@ -170,9 +170,10 @@ class SpecificImpedanceInputs(SpecificImpedanceInputs_UI):
 
     def attribute_callback(self):
         tab_index = self.tabWidget_main.currentIndex()
-        if tab_index == 0:
+        if tab_index == StandardTabType.CONSTANT_DATA:
             self.check_constant_values()
-        elif tab_index == 1:
+
+        elif tab_index == StandardTabType.TABULAR_DATA:
             self.check_table_values()
 
     def check_complex_entries(self, lineEdit_real, lineEdit_imag):
@@ -505,11 +506,11 @@ class SpecificImpedanceInputs(SpecificImpedanceInputs_UI):
             if property == "specific_impedance":
                 if "anechoic_termination" in data.keys():
                     continue
-                self.tabWidget_main.setTabVisible(2, True)
+                self.tabWidget_main.setTabVisible(StandardTabType.LIST, True)
                 return
 
-        self.tabWidget_main.setCurrentIndex(0)
-        self.tabWidget_main.setTabVisible(2, False)
+        self.tabWidget_main.setCurrentIndex(StandardTabType.CONSTANT_DATA)
+        self.tabWidget_main.setTabVisible(StandardTabType.LIST, False)
 
     def keyPressEvent(self, event):
         if event.key() == Qt.Key_Enter or event.key() == Qt.Key_Return:

--- a/vibra/interface/model_inputs/acoustic/internal_impedances/perforated_plate_model_inputs.py
+++ b/vibra/interface/model_inputs/acoustic/internal_impedances/perforated_plate_model_inputs.py
@@ -12,6 +12,7 @@ from vibra.interface.model_inputs.general.fluid.simplified_fluid_inputs import S
 from vibra.interface.model_inputs.acoustic.internal_impedances.perforated_plate_data import PerforatedPlateData
 from vibra.interface.plots.general.frequency_response_plotter import FrequencyResponsePlotter
 from vibra.interface.ui_generated.model.setup.acoustic.perforated_plate_model_inputs_ui import PerforatedPlateModelInputs_UI
+from vibra.interface.model_inputs.acoustic.definitions.enums import SetupTabType
 
 from vibra.engine.properties.fluid import Fluid
 from vibra.engine.transfer_impedances.perforated_plate_models import PerforatedPlateModels
@@ -23,10 +24,27 @@ from typing import Dict, List
 
 import logging, warnings
 import numpy as np
+from enum import IntEnum
 
 error_title = "Error"
 warning_title = "Warning"
 
+class PPMMainTabType(IntEnum):
+    SETUP = SetupTabType.SETUP
+    EDIT = 1
+    LIST = 2
+
+class PPlateModelsTabType(IntEnum):
+    CIRCULAR_HOLES = 0
+
+class PlotTypeBoxType(IntEnum):
+    ACOUSTIC_IMPEDANCE = 0
+
+class IncludeEffectsBoxType(IntEnum):
+    NONE = 0
+    NON_LINEAR = 1
+    USER_DEFINED = 2
+    NON_LINEAR_AND_USER_DEFINED = 3
 
 class PerforatedPlateModelInputs(PerforatedPlateModelInputs_UI):
     def __init__(self, *args, **kwargs):
@@ -99,7 +117,7 @@ class PerforatedPlateModelInputs(PerforatedPlateModelInputs_UI):
 
     def geometry_selection_callback(self):
 
-        if self.tabWidget_main.currentIndex() != 0:
+        if self.tabWidget_main.currentIndex() != PPMMainTabType.SETUP:
             return
 
         surfaces = app().main_window.selected_geometry_surfaces
@@ -121,7 +139,7 @@ class PerforatedPlateModelInputs(PerforatedPlateModelInputs_UI):
 
         formulation = data.get("formulation")
         if formulation == "circular_hole":
-            self.tabWidget_perforated_plate_models.setCurrentIndex(0)
+            self.tabWidget_perforated_plate_models.setCurrentIndex(PPlateModelsTabType.CIRCULAR_HOLES)
 
         t_p = data.get("plate_thickness")
         if isinstance(t_p, float | int):
@@ -156,7 +174,7 @@ class PerforatedPlateModelInputs(PerforatedPlateModelInputs_UI):
         table_path = data.get("table_paths")
         if table_path is None:
             if self.lineEdit_non_linear_discharge_coefficient.isEnabled():
-                self.comboBox_include_effects.setCurrentIndex(1)
+                self.comboBox_include_effects.setCurrentIndex(IncludeEffectsBoxType.NON_LINEAR)
 
             self.pushButton_load_path.setEnabled(False)
             self.lineEdit_user_defined_transfer_impedance_path.setText("")
@@ -165,9 +183,9 @@ class PerforatedPlateModelInputs(PerforatedPlateModelInputs_UI):
 
         elif isinstance(table_path, list):
             if self.lineEdit_non_linear_discharge_coefficient.isEnabled():
-                self.comboBox_include_effects.setCurrentIndex(3)
+                self.comboBox_include_effects.setCurrentIndex(IncludeEffectsBoxType.NON_LINEAR_AND_USER_DEFINED)
             else:
-                self.comboBox_include_effects.setCurrentIndex(2)
+                self.comboBox_include_effects.setCurrentIndex(IncludeEffectsBoxType.USER_DEFINED)
 
             self.pushButton_load_path.setEnabled(True)
             self.lineEdit_user_defined_transfer_impedance_path.setEnabled(True)
@@ -231,9 +249,9 @@ class PerforatedPlateModelInputs(PerforatedPlateModelInputs_UI):
 
     def tab_event_callback(self):
         current_tab = self.tabWidget_main.currentIndex()
-        tab_list = current_tab == 2
+        tab_list = current_tab == PPMMainTabType.LIST
 
-        if self.last_tab == 2 or tab_list:
+        if self.last_tab == PPMMainTabType.LIST or tab_list:
             app().main_window.clear_selection()
             self.lineEdit_selection_id.clear()
 
@@ -479,14 +497,14 @@ class PerforatedPlateModelInputs(PerforatedPlateModelInputs_UI):
     def update_tabs_visibility(self):
 
         if len(self.map_model_id_to_model) > 0:
-            self.tabWidget_main.setTabVisible(1, True)
-            self.tabWidget_main.setTabVisible(2, True)
+            self.tabWidget_main.setTabVisible(PPMMainTabType.EDIT, True)
+            self.tabWidget_main.setTabVisible(PPMMainTabType.LIST, True)
 
             return
 
-        self.tabWidget_main.setCurrentIndex(0)
-        self.tabWidget_main.setTabVisible(1, False)
-        self.tabWidget_main.setTabVisible(2, False)
+        self.tabWidget_main.setCurrentIndex(PPMMainTabType.SETUP)
+        self.tabWidget_main.setTabVisible(PPMMainTabType.EDIT, False)
+        self.tabWidget_main.setTabVisible(PPMMainTabType.LIST, False)
 
     def load_table(self, lineEdit : QLineEdit = None, direct_load: bool=False) -> np.ndarray:
 
@@ -569,7 +587,7 @@ class PerforatedPlateModelInputs(PerforatedPlateModelInputs_UI):
 
     def get_inputs_for_perforated_plate_with_circular_holes(self) -> PerforatedPlateData:
 
-        if self.tabWidget_perforated_plate_models.currentIndex() != 0:
+        if self.tabWidget_perforated_plate_models.currentIndex() != PPlateModelsTabType.CIRCULAR_HOLES:
             return
         
         if self.selected_fluid is None:
@@ -1030,12 +1048,12 @@ class PerforatedPlateModelInputs(PerforatedPlateModelInputs_UI):
     def get_perforated_plate_model(self):
         tab_index = self.tabWidget_main.currentIndex()
         
-        if tab_index == 0:
+        if tab_index == PPMMainTabType.SETUP:
             return "circular hole"
 
     def plot_data_callback(self):
         plot_key = self.comboBox_plot_type.currentIndex()
-        if plot_key == 0:
+        if plot_key == PlotTypeBoxType.ACOUSTIC_IMPEDANCE:
             self.plot_perforated_plate_impedance()
 
     def plot_perforated_plate_impedance(self):

--- a/vibra/interface/model_inputs/acoustic/internal_impedances/transfer_impedance_inputs.py
+++ b/vibra/interface/model_inputs/acoustic/internal_impedances/transfer_impedance_inputs.py
@@ -9,6 +9,7 @@ from vibra.interface.general.get_user_confirmation_input import GetUserConfirmat
 from vibra.interface.general.print_message_input import PrintMessageInput
 from vibra.interface.loading_window import LoadingWindow
 from vibra.interface.ui_generated.model.setup.acoustic.transfer_impedance_inputs_ui import TransferImpedanceInputs_UI
+from vibra.interface.model_inputs.acoustic.definitions.enums import StandardTabType
 
 from copy import deepcopy
 
@@ -96,7 +97,7 @@ class TransferImpedanceInputs(TransferImpedanceInputs_UI):
 
     def geometry_selection_callback(self):
 
-        if self.tabWidget_main.currentIndex() != 0:
+        if self.tabWidget_main.currentIndex() != StandardTabType.CONSTANT_DATA:
             return
 
         surfaces = app().main_window.selected_geometry_surfaces
@@ -116,17 +117,17 @@ class TransferImpedanceInputs(TransferImpedanceInputs_UI):
 
     def load_property_data(self, pp_data: dict):
 
-        if self.tabWidget_main.currentIndex() == 2:
+        if self.tabWidget_main.currentIndex() == StandardTabType.LIST:
             return
         
         if not isinstance(pp_data, dict):
             return
         
         if "table_paths" in pp_data.keys():
-            self.tabWidget_main.setCurrentIndex(1)
+            self.tabWidget_main.setCurrentIndex(StandardTabType.TABULAR_DATA)
             self.lineEdit_table_path.setText(pp_data["table_paths"][0])
         else:
-            self.tabWidget_main.setCurrentIndex(0)
+            self.tabWidget_main.setCurrentIndex(StandardTabType.CONSTANT_DATA)
             self.lineEdit_real_value.setText(str(pp_data["real_values"][0]))
             self.lineEdit_imag_value.setText(str(pp_data["imag_values"][0]))
 
@@ -155,7 +156,7 @@ class TransferImpedanceInputs(TransferImpedanceInputs_UI):
     def attribute_callback(self):
 
         tab_index = self.tabWidget_main.currentIndex()
-        if tab_index == 2:
+        if tab_index == StandardTabType.LIST:
             return
 
         surface_ids = self.check_selected_surfaces()
@@ -164,10 +165,10 @@ class TransferImpedanceInputs(TransferImpedanceInputs_UI):
 
         self.remove_conflicting_excitations(surface_ids)
 
-        if tab_index == 0:
+        if tab_index == StandardTabType.CONSTANT_DATA:
             self.process_assignment_for_constant_values(surface_ids)
 
-        elif tab_index == 1:
+        elif tab_index == StandardTabType.TABULAR_DATA:
             self.process_assignment_for_table_values(surface_ids)
 
         self.lineEdit_selection_id.setText("")
@@ -323,9 +324,9 @@ class TransferImpedanceInputs(TransferImpedanceInputs_UI):
 
     def tab_event_callback(self):
         current_tab = self.tabWidget_main.currentIndex()
-        tab_list = current_tab == 2
+        tab_list = current_tab == StandardTabType.LIST
 
-        if self.last_tab == 2 or tab_list:
+        if self.last_tab == StandardTabType.LIST or tab_list:
             app().main_window.clear_selection()
             self.lineEdit_selection_id.clear()
 
@@ -417,11 +418,11 @@ class TransferImpedanceInputs(TransferImpedanceInputs_UI):
         for key, _ in self.properties.surface_properties.items():
             property, _ = key
             if property == "transfer_impedance":
-                self.tabWidget_main.setTabVisible(2, True)
+                self.tabWidget_main.setTabVisible(StandardTabType.LIST, True)
                 return
 
-        self.tabWidget_main.setCurrentIndex(0)
-        self.tabWidget_main.setTabVisible(2, False)
+        self.tabWidget_main.setCurrentIndex(StandardTabType.CONSTANT_DATA)
+        self.tabWidget_main.setTabVisible(StandardTabType.LIST, False)
 
     def load_user_defined_transfer_impedance(self):
         self.imported_values = self.load_table(self.lineEdit_user_defined_transfer_impedance_path)


### PR DESCRIPTION
This pull request aims to improve code **readability** in the Acoustic Model Setup Input files. Previously, the code relied on raw indexes ("magic numbers") to refer to specific TabWidgets. This approach made the code difficult to interpret at a glance, as it wasn't immediately clear which tab an integer represented.

To address this, I introduced descriptive Enums. Now, the code explicitly references the tab purpose, making it self-documenting.

**Key Changes**
- **Created enums.py:** A new file containing general Enums used by most Acoustic Model Setup files.
- **Custom Enums:** For files with slightly different tab structures, specific Enums were created that reuse as many attributes as possible from the general Enum.
- **Refactoring:** Replaced raw integer comparisons with Enum members across the affected files.

To clarify this, let's take the acoustic_pressure_inputs.py as an example:

Before (using raw indexes):
```
    def attribute_callback(self):
        tab_index = self.tabWidget_main.currentIndex()
        if tab_index == 0:
            self.check_constant_values()

        elif tab_index == 1:
            self.check_table_values()
```

After (using Enums):

```
    def attribute_callback(self):
        tab_index = self.tabWidget_main.currentIndex()
        if tab_index == StandardTabType.CONSTANT_DATA:
            self.check_constant_values()

        elif tab_index == StandardTabType.TABULAR_DATA:
            self.check_table_values()
```

As shown above, using Enums eliminates ambiguity compared to loose integers, allowing to instantly understand which TabWidget is being referenced.