### PR TITLE
Fix Zoom to Fit issue caused by symbols

### DIFF
--- a/vibra/interface/main_window.py
+++ b/vibra/interface/main_window.py
@@ -1125,11 +1125,7 @@ class MainWindow(MainWindow_UI):
     def action_zoom_to_fit_callback(self):
         widget = self.render_widgets_stack.currentWidget()
         if isinstance(widget, CommonRenderWidget):
-            # the symbols are bugging the zoom, need to deactivate first
-            symbols_state = self.visualization_filter.symbols
-            self.action_hide_show_symbols_callback(False)
             widget.renderer.ResetCamera()
-            self.action_hide_show_symbols_callback(symbols_state)
             widget.update()
 
     def action_hide_show_symbols_callback(self, clicked: bool):

--- a/vibra/interface/viewer_3d/actors/symbols_actor_acoustic.py
+++ b/vibra/interface/viewer_3d/actors/symbols_actor_acoustic.py
@@ -13,6 +13,8 @@ class SymbolsActorAcoustic(CommonSymbolsActorVariableSize):
         self.configure_appearance()
         self.build()
         self.set_zbuffer_offsets(1, -6600)
+        # as the symbols do not change size when zooming, this is needed for reset_camera to work properly
+        self.UseBoundsOff()
 
     def configure_appearance(self):
         self.GetProperty().SetAmbient(0.5)

--- a/vibra/interface/viewer_3d/actors/symbols_actor_structural.py
+++ b/vibra/interface/viewer_3d/actors/symbols_actor_structural.py
@@ -16,6 +16,8 @@ class SymbolsActorStructural(CommonSymbolsActorVariableSize):
         self.configure_appearance()
         self.build()
         self.set_zbuffer_offsets(1, -6600)
+        # as the symbols do not change size when zooming, this is needed for reset_camera to work properly
+        self.UseBoundsOff()
 
     def configure_appearance(self):
         self.GetProperty().SetAmbient(0.5)


### PR DESCRIPTION
The "Zoom to Fit" feature was failing to calculate bounds correctly when symbols were present. This fix forces a state refresh by temporarily deactivating and reactivating the symbols, ensuring the camera resets properly.