### PR TITLE
Adjustments in the DOF decoupling icon visibility

### DIFF
--- a/vibra/interface/menus/model_setup_items.py
+++ b/vibra/interface/menus/model_setup_items.py
@@ -250,6 +250,10 @@ class ModelSetupItems(CommonMenuItems):
                         if isinstance(pp_data, dict):
                             continue
 
+                        ti_data = properties._get_property("transfer_impedance", surface=key[1])
+                        if isinstance(ti_data, dict):
+                            continue
+
                     return True
 
         return False

--- a/vibra/interface/model_inputs/general/degrees_of_freedom_decoupling_inputs.py
+++ b/vibra/interface/model_inputs/general/degrees_of_freedom_decoupling_inputs.py
@@ -322,6 +322,10 @@ class DegreesOfFreedomDecouplingInputs(DegreesOfFreedomDecouplingInputs_UI):
                 pp_data =  self.properties._get_property("perforated_plate_model", surface=surface_id)
                 if isinstance(pp_data, dict):
                     continue
+
+                ti_data =  self.properties._get_property("transfer_impedance", surface=surface_id)
+                if isinstance(ti_data, dict):
+                    continue
  
                 volume_id = data.get("volume_to_decouple")
                 if volume_id is None:


### PR DESCRIPTION
Do not show the DOF decoupling menu item icon if only transfer impedances are active in the acoustic model.