### PR TITLE
fixes symbols on surfaces with insufficient curvature

### DIFF
--- a/vibra/interface/viewer_3d/actors/symbols_actor_acoustic.py
+++ b/vibra/interface/viewer_3d/actors/symbols_actor_acoustic.py
@@ -80,7 +80,7 @@ class SymbolsActorAcoustic(CommonSymbolsActorVariableSize):
             avg_normal = np.average(surface_normals, axis=0).round(6)
 
         curvatures_surface = mesh.curvatures_surface.get(surface_id)
-        contains_curvature = (curvatures_surface is not None) and np.any(curvatures_surface)
+        contains_curvature = (curvatures_surface is not None) and (np.average(curvatures_surface) > 1e-4)
         center_coords = np.average(surface_coordinates, axis=0)
 
         if contains_curvature:


### PR DESCRIPTION
Surface normal calculations were slightly off on surfaces with minimal curvature. This PR use an 'if' to check these cases.