### PR TITLE
Avoid blank structures in the mesh workspace

### DIFF
--- a/vibra/engine/model.py
+++ b/vibra/engine/model.py
@@ -299,6 +299,14 @@ class Model:
         cond_B = len(self.solution_steps_mask) != int(sum(self.solution_steps_mask))
         return cond_A or cond_B
 
+    def is_the_mesh_setup_defined(self):
+        if isinstance(self.geometry_path, str | Path):
+            if self.is_there_a_geometry_imported():
+                if not isinstance(self.mesh_setup, MeshSetup):
+                    return True
+
+        return False
+
     def is_there_a_valid_mesh(self):
 
         if isinstance(self.geometry_path, str | Path):

--- a/vibra/interface/main_window.py
+++ b/vibra/interface/main_window.py
@@ -26,6 +26,7 @@ from vibra.interface.help_widget import HelpWidget
 from vibra.interface.loading_window import LoadingWindow
 from vibra.interface.menus.model_setup_widget import ModelSetupWidget
 from vibra.interface.menus.results_viewer_widget import ResultsViewerWidget
+from vibra.interface.model_inputs.general.mesher_setup_inputs import MesherSetupInputs
 from vibra.interface.plots.acoustic.export_element_transfer_data_inputs import ExportElementTransferDataInputs
 from vibra.interface.project.save_project_data_selector import SaveProjectDataSelector
 from vibra.interface.render_tools_toolbar import RenderToolsToolbar
@@ -510,6 +511,12 @@ class MainWindow(MainWindow_UI):
         self.action_results_workspace.setChecked(False)
 
         self.render_tools_toolbar.show_selection_tool()
+
+        if app().project.model.is_the_mesh_setup_defined():
+            obj = MesherSetupInputs(close_after_generate=True)
+            if not obj.complete:
+                self.action_model_workspace_callback()
+                return
 
         valid_solution = app().project.is_there_a_valid_solution()
         self.action_results_workspace.setEnabled(valid_solution)


### PR DESCRIPTION
This pull request implements a check to confirm whether a mesh has already been generated before switching to the mesh workspace. If the mesh has not yet been generated, the MesherSetup user interface will open, and the mesh workspace will be updated after the mesh has been processed. Otherwise, if no mesh is generated, the workspace will be returned to the model setup workspace. This PR closes #372.