### PR TITLE
Reduce intialization time

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dev = [
     "pytest-datadir>=1.7.2,<2",
     "invoke>=2.2.0,<3",
     "pyinstaller>=6.20.0",
+    "tuna>=0.5.15",
 ]
 
 [build-system]

--- a/uv.lock
+++ b/uv.lock
@@ -1667,6 +1667,15 @@ wheels = [
 ]
 
 [[package]]
+name = "tuna"
+version = "0.5.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cf/79/2321629fc8838b07ca0b2851a8e4ebf99d4a36c2d3fecd3dc391c9dba9a9/tuna-0.5.15.tar.gz", hash = "sha256:0109ab102374ecf5d47f950267b516b6009c3cf48e8caba3b2c859ed3f6fb996", size = 162409, upload-time = "2026-05-19T09:31:42.049Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/c7/622f828d2d6e73826f46d7589f1d3be9812cef5827076040c9fa06b80f7e/tuna-0.5.15-py3-none-any.whl", hash = "sha256:889a62552067133e86851cebb1042bfc28242141ea80d4ae9c64142d86e060a3", size = 160492, upload-time = "2026-05-19T09:31:40.665Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1742,6 +1751,7 @@ dev = [
     { name = "pyinstaller" },
     { name = "pytest" },
     { name = "pytest-datadir" },
+    { name = "tuna" },
 ]
 
 [package.metadata]
@@ -1775,6 +1785,7 @@ dev = [
     { name = "pyinstaller", specifier = ">=6.20.0" },
     { name = "pytest", specifier = ">=8.3.5,<9" },
     { name = "pytest-datadir", specifier = ">=1.7.2,<2" },
+    { name = "tuna", specifier = ">=0.5.15" },
 ]
 
 [[package]]

--- a/vibra/interface/application.py
+++ b/vibra/interface/application.py
@@ -1,4 +1,3 @@
-from PySide6.QtCore import Signal
 from PySide6.QtWidgets import QApplication
 
 from vibra import TEMP_PROJECT_DIR
@@ -6,8 +5,6 @@ from vibra.interface.splash_screen import SplashScreen
 
 
 class Application(QApplication):
-    selection_changed = Signal()
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/vibra/interface/application.py
+++ b/vibra/interface/application.py
@@ -1,13 +1,8 @@
-from PySide6.QtCore import Qt, Signal
+from PySide6.QtCore import Signal
 from PySide6.QtWidgets import QApplication
 
 from vibra import TEMP_PROJECT_DIR
-from vibra.engine.project import Project
-from vibra.interface.config import Config
-from vibra.interface.main_window import MainWindow
 from vibra.interface.splash_screen import SplashScreen
-
-QApplication.setAttribute(Qt.AA_ShareOpenGLContexts)
 
 
 class Application(QApplication):
@@ -22,10 +17,17 @@ class Application(QApplication):
         self.processEvents()
 
         # global params
+        from vibra.interface.config import Config
+
         self.config = Config()
+
+        from vibra.engine.project import Project
+
         self.project = Project(TEMP_PROJECT_DIR)
 
         # gui
+        from vibra.interface.main_window import MainWindow
+
         self.main_window = MainWindow()
         self.main_window.configure_main_window()
         self.filter_tab_scroll_by_wheel()

--- a/vibra/interface/model_inputs/acoustic/excitations/compressor_excitation_waveform_inputs.py
+++ b/vibra/interface/model_inputs/acoustic/excitations/compressor_excitation_waveform_inputs.py
@@ -2,7 +2,6 @@ from copy import deepcopy
 from pathlib import Path
 
 import numpy as np
-import sounddevice as sd
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QCloseEvent
 from PySide6.QtWidgets import QLineEdit, QTreeWidgetItem
@@ -956,6 +955,7 @@ class CompressorExcitationWaveformInputs(CompressorExcitationWaveformInputs_UI):
         self.waveform_plotter._set_model_results_data_to_plot(self.model_results)
 
     def reproduce_audio_callback(self):
+        import sounddevice as sd
 
         if self.x_data is None:
             return

--- a/vibra/launch.py
+++ b/vibra/launch.py
@@ -93,6 +93,8 @@ def main():
     # Make the window scale evenly for every monitor
     os.environ["QT_AUTO_SCREEN_SCALE_FACTOR"] = "1"
 
+    Application.setAttribute(Qt.ApplicationAttribute.AA_ShareOpenGLContexts)
+
     if platform.system() == "Linux":
         # Ensure the use of X11 instead of Wayland in Linux systems
         # This is needed because VTK is not compatible with Wayland


### PR DESCRIPTION
This PR reorganizes a few imports to make the software initialization feel faster.
The time to start using the software is about the same, but the Splash Screen is appearing earlier.
We improved from about 16 seconds to only two.

I am not sure if it is a fluke, please let me know if the software is still slow.

Closes #419 