### PR TITLE
Add a loading window during the initialization of the fluid composition UI

### DIFF
--- a/vibra/interface/model_inputs/general/fluid/refprop_interface.py
+++ b/vibra/interface/model_inputs/general/fluid/refprop_interface.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import re
 from pathlib import Path
@@ -7,10 +8,7 @@ from PySide6.QtWidgets import QFileDialog
 
 from vibra import app
 from vibra.interface import error_title, warning_title
-# from vibra.interface.general.get_user_confirmation_input import GetUserConfirmationInput
 from vibra.interface.general.print_message_input import PrintMessageInput
-from vibra.utils.utils import get_new_path
-
 
 IS_ERROR_REGEX = re.compile(r"\[\w+\s+error")
 IS_WARNING_REGEX = re.compile(r"\[\w+\s+warning")
@@ -28,20 +26,22 @@ class RefpropInterface:
         # self.isentropic_label = "ISENK"   # isentropic exponent (real gas)
         self.isentropic_label = "CP/CV"     # isentropic expansion coefficient (ideal gas)
 
-        self.map_properties = { "D" : "fluid_density",
-                                "CP" : "specific_heat_Cp",
-                                "CV" : "specific_heat_Cv",
-                                self.isentropic_label : "isentropic_exponent",
-                                "W" : "speed_of_sound",
-                                "VIS" : "dynamic_viscosity",
-                                "TCX" : "thermal_conductivity",
-                                "PRANDTL" : "Prandtl_number",
-                                "TD" : "thermal_diffusivity",
-                                "KV" : "kinematic_viscosity",
-                                "M" : "molar_mass",
-                                "BS" : "adiabatic_bulk_modulus",
-                                "KKT" : "isothermal_bulk_modulus",
-                                "Z" : "compressibility_factor"  }
+        self.map_properties = { 
+            "D" : "fluid_density",
+            "CP" : "specific_heat_Cp",
+            "CV" : "specific_heat_Cv",
+            self.isentropic_label : "isentropic_exponent",
+            "W" : "speed_of_sound",
+            "VIS" : "dynamic_viscosity",
+            "TCX" : "thermal_conductivity",
+            "PRANDTL" : "Prandtl_number",
+            "TD" : "thermal_diffusivity",
+            "KV" : "kinematic_viscosity",
+            "M" : "molar_mass",
+            "BS" : "adiabatic_bulk_modulus",
+            "KKT" : "isothermal_bulk_modulus",
+            "Z" : "compressibility_factor",
+        }
 
     def get_refprop_path(self) -> None | str:
 
@@ -90,10 +90,12 @@ class RefpropInterface:
             return True
 
     def initialize_REFPROP(self):
+
         try:
             
             from ctREFPROP.ctREFPROP import REFPROPFunctionLibrary
 
+            logging.info("Loading REFPROP interface [30%]")
             refProp_path = self.get_refprop_path()
             if refProp_path is None:
                 return True
@@ -105,43 +107,41 @@ class RefpropInterface:
                 PrintMessageInput([error_title, title, message])
                 return True
 
+            logging.info("Loading REFPROP interface [40%]")
             self.refprop = REFPROPFunctionLibrary(refProp_path)
             if self.check_refprop_version():
                 return True
-
+ 
+            logging.info("Loading REFPROP interface [50%]")
             self.refprop.SETPATHdll(refProp_path)
-            refProp_fluids_path = get_new_path(refProp_path, "FLUIDS")
-            list_files = os.listdir(refProp_fluids_path)
+            refProp_fluids_path = Path(refProp_path) / "FLUIDS"
 
             self.refprop_fluids = dict()
             self.fluid_file_to_final_name = dict()
 
-            for fluid_file in list_files:
-                if ".BNC" not in fluid_file:
-                    filepath = get_new_path(refProp_fluids_path, fluid_file)
-                    
-                    f = open(filepath, 'r')
-                    line_0 = f.readline()
-                    line_1 = f.readline()
-                    line_2 = f.readline()
+            for fluid_file in os.listdir(refProp_fluids_path):
+                if ".BNC" in fluid_file:
+                    continue
 
-                    f.close()
-                    short_name = line_0.split("!")[0]
-                    full_name = line_2.split("!")[0]
-            
-                    letter = " "
-                    while letter == " ":
-                        short_name = short_name[:-1]
-                        letter = short_name[-1]
-                        
-                    letter = " "
-                    while letter == " ":
-                        full_name = full_name[:-1]
-                        letter = full_name[-1]
+                filepath = Path(refProp_fluids_path) / fluid_file
 
-                    final_name = short_name if short_name == full_name else f"{short_name} ({full_name})"
-                    self.refprop_fluids[final_name] = [fluid_file, short_name, full_name]
-                    self.fluid_file_to_final_name[fluid_file] = final_name
+                f = open(filepath, 'r')
+                line_0 = f.readline()
+                line_1 = f.readline()
+                line_2 = f.readline()
+
+                f.close()
+                short_name = line_0.split("!")[0]
+                full_name = line_2.split("!")[0]
+
+                # remove empty rear spaces
+                short_name = short_name.rstrip()
+                full_name = full_name.rstrip()
+
+                final_name = short_name if short_name == full_name else f"{short_name} ({full_name})"
+
+                self.refprop_fluids[final_name] = [fluid_file, short_name, full_name]
+                self.fluid_file_to_final_name[fluid_file] = final_name
 
         except Exception as error_log:
             title = "Error while loading REFPROP"
@@ -163,16 +163,16 @@ class RefpropInterface:
         
         units = self.refprop.GETENUMdll(0, "MASS BASE SI").iEnum
         read = self.refprop.REFPROPdll( 
-                                        key_mixture, 
-                                        state_properties, 
-                                        property_key, 
-                                        units, 
-                                        0, 
-                                        0, 
-                                        temperature_K, 
-                                        pressure_Pa, 
-                                        molar_fractions
-                                        )
+            key_mixture,
+            state_properties,
+            property_key,
+            units,
+            0,
+            0,
+            temperature_K,
+            pressure_Pa,
+            molar_fractions,
+            )
 
         if IS_ERROR_REGEX.match(read.herr):
             errors = read.herr
@@ -221,12 +221,12 @@ class RefpropInterface:
 
             for prop_key, prop_label in self.map_properties.items():
                 fluid_property, errors, warnings = self.get_specific_fluid_property(
-                                                                          key_mixture = key_mixture,
-                                                                          molar_fractions = molar_fractions,
-                                                                          property_key = prop_key,
-                                                                          temperature_K = temperature_K,
-                                                                          pressure_Pa = pressure_Pa,
-                                                                          )
+                    key_mixture = key_mixture,
+                    molar_fractions = molar_fractions,
+                    property_key = prop_key,
+                    temperature_K = temperature_K,
+                    pressure_Pa = pressure_Pa,
+                )
 
                 if errors:
                     print(errors)

--- a/vibra/interface/model_inputs/general/fluid/set_fluid_composition_inputs.py
+++ b/vibra/interface/model_inputs/general/fluid/set_fluid_composition_inputs.py
@@ -1,3 +1,4 @@
+import logging
 from enum import IntEnum
 
 from PySide6.QtCore import Qt
@@ -13,6 +14,7 @@ from vibra.engine.properties.fluid import Fluid
 from vibra.interface import error_title, warning_title
 from vibra.interface.general.get_user_confirmation_input import GetUserConfirmationInput
 from vibra.interface.general.print_message_input import PrintMessageInput
+from vibra.interface.loading_window import LoadingWindow
 from vibra.interface.model_inputs.general.fluid.load_fluid_composition_inputs import (
     LoadFluidCompositionInputs,
 )
@@ -49,7 +51,7 @@ class SetFluidCompositionInputs(SetFluidCompositionInput_UI):
             self.check_state_properties(self.state_properties)
 
         self.update_remainig_composition()
-        if self.initialize_refprop_interface():
+        if LoadingWindow(self.initialize_refprop_interface).run():
             return
 
         self.update_selected_fluid(fluid_to_edit = self.fluid_to_edit)
@@ -85,15 +87,19 @@ class SetFluidCompositionInputs(SetFluidCompositionInput_UI):
         self.composition_file_path = ""
 
     def initialize_refprop_interface(self):
+        logging.info("Loading REFPROP interface [10%]")
         self.refprop_interface = RefpropInterface()
+
         if self.refprop_interface.initialize_REFPROP():
             return True
-
+        
+        logging.info("Loading REFPROP interface [80%]")
         self.refprop = self.refprop_interface.refprop
         self.load_default_gases_info(self.refprop_interface.refprop_fluids)
 
+        logging.info("Loading REFPROP interface [95%]")
         version = self.refprop_interface.get_REFPROP_version()
-        self.setWindowTitle(f"Vibra (REFPROP v{version})")
+        self.setWindowTitle(f"OpenPulse (REFPROP v{version})")
 
     def _create_connections(self):
         #


### PR DESCRIPTION
This pull request adds a loading window during the initialization of the fluid composition user interface. I took the opportunity to simplify the methods for reading the REFPROP fluids library. It also resolves the issue #427.