### PR TITLE
Update StrictDoubleValidator to allow empty strings

### DIFF
--- a/vibra/interface/numeric_checks/double_validator.py
+++ b/vibra/interface/numeric_checks/double_validator.py
@@ -23,7 +23,7 @@ class StrictDoubleValidator(QDoubleValidator):
         string = string.replace(",", ".")
 
         if not string:
-            return QDoubleValidator.State.Intermediate, string, pos
+            return QDoubleValidator.State.Acceptable, string, pos
 
         if string.count(".") > 1:
             return QDoubleValidator.State.Invalid, string, pos


### PR DESCRIPTION
Allow empty strings in the StrictDoubleValidator to avoid the previous annoyance.