### PR TITLE
Updates the filter to the wheel scroll event

### DIFF
--- a/vibra/interface/application.py
+++ b/vibra/interface/application.py
@@ -27,18 +27,22 @@ class Application(QApplication):
 
         self.main_window = MainWindow()
         self.main_window.configure_main_window()
-        self.filter_tab_scroll_by_wheel()
+        self.filter_scroll_by_wheel_event()
 
-    def filter_tab_scroll_by_wheel(self):
+    def filter_scroll_by_wheel_event(self):
         from PySide6.QtCore import QEvent, QObject
-        from PySide6.QtWidgets import QTabBar
+        from PySide6.QtWidgets import QTabBar, QSpinBox, QComboBox
 
         class Filter(QObject):
             def eventFilter(self, obj, event):
-                if isinstance(obj, QTabBar) and (event.type() == QEvent.Wheel):
-                    return True
-                else:
+                if event.type() != QEvent.Wheel:
                     return False
+                
+                widgets = [QTabBar, QSpinBox, QComboBox]
+                for widget in widgets:
+                    if isinstance(obj, widget):
+                        return True
+                return False
 
         filter = Filter(self)
         self.installEventFilter(filter)

--- a/vibra/interface/application.py
+++ b/vibra/interface/application.py
@@ -31,14 +31,14 @@ class Application(QApplication):
 
     def filter_scroll_by_wheel_event(self):
         from PySide6.QtCore import QEvent, QObject
-        from PySide6.QtWidgets import QTabBar, QSpinBox, QComboBox
+        from PySide6.QtWidgets import QTabBar, QAbstractSpinBox, QComboBox
 
         class Filter(QObject):
             def eventFilter(self, obj, event):
                 if event.type() != QEvent.Wheel:
                     return False
                 
-                widgets = [QTabBar, QSpinBox, QComboBox]
+                widgets = [QTabBar, QAbstractSpinBox, QComboBox]
                 for widget in widgets:
                     if isinstance(obj, widget):
                         return True


### PR DESCRIPTION
## What does this PR do?

This PR disables the scroll event for `QTabBar`, `QAbstractSpinBox` and `QComboBox` widgets.

To do this, I only updated the `eventFilter` method from the `Filter` class, in the `Application`. Now, the method filter this event for `QTabBar`,  `QAbstractSpinBox` and `QComboBox` widgets.

Closes #385 