### PR TITLE
Add deletion shortcuts

### DIFF
--- a/vibra/interface/model_inputs/general/choose_property_to_delete.py
+++ b/vibra/interface/model_inputs/general/choose_property_to_delete.py
@@ -21,6 +21,10 @@ class ChoosePropertyToDelete(ChoosePropertyToDelete_UI):
         if not self.properties_formated:
             return
 
+        if len(self.properties_formated) == 1:
+            self.tableWidget.selectAll()
+            self.remove_callback()
+
         self._config_window()
         self._create_connections()
         self._configure_filter_timer()
@@ -143,6 +147,7 @@ class ChoosePropertyToDelete(ChoosePropertyToDelete_UI):
                 self.tableWidget.setItem(row_index, column_index, item)
 
         self.tableWidget.setSortingEnabled(True)
+        self.tableWidget.selectAll()
 
     def filter_table(self):
         filter_text = self.lineEdit_filter.text().lower().replace(" ", "_")


### PR DESCRIPTION
This PR updates the delete window behavior:

- When only one property is selected, the confirmation is shown directly without displaying the options table.
- All properties are selected by default.

Closes #455 
Closes #456 