### PR TITLE
Entity visibility handler

### DIFF
--- a/vibra/interface/general/entity_visibility_handler.py
+++ b/vibra/interface/general/entity_visibility_handler.py
@@ -1,0 +1,51 @@
+from typing import Sequence
+
+from PySide6.QtCore import QObject, Signal
+
+from vibra.engine.project import Project
+
+
+class EntityVisibilityHandler(QObject):
+    changed = Signal()
+
+    def __init__(self, project: Project):
+        self.project = project
+
+        self._surfaces_to_hide = set()
+        self._volumes_to_hide = set()
+
+    def get_visible_surfaces(self) -> set[int]:
+        mesh = self.project.mesh
+        if mesh is None:
+            return set()
+
+        _visible_surfaces = set()
+        for volume, surfaces in mesh.surfaces_from_volume.items():
+            if volume not in self._volumes_to_hide:
+                _visible_surfaces |= surfaces
+
+        _visible_surfaces -= self._surfaces_to_hide
+        return _visible_surfaces
+
+    def get_hidden_surfaces(self) -> set[int]:
+        mesh = self.project.mesh
+        if mesh is None:
+            return set()
+
+        all_surfaces = mesh.all_surface_ids()
+        return all_surfaces - self.get_visible_surfaces()
+
+    def hide_surfaces(self, surfaces: Sequence[int]):
+        self._surfaces_to_hide |= set(surfaces)
+        if surfaces:
+            self.changed.emit()
+
+    def hide_volumes(self, volumes: Sequence[int]):
+        self._volumes_to_hide |= set(volumes)
+        if volumes:
+            self.changed.emit()
+
+    def unhide_all(self):
+        self._surfaces_to_hide.clear()
+        self._volumes_to_hide.clear()
+        self.changed.emit()

--- a/vibra/interface/general/entity_visibility_handler.py
+++ b/vibra/interface/general/entity_visibility_handler.py
@@ -22,7 +22,7 @@ class EntityVisibilityHandler(QObject):
         _visible_surfaces = set()
         for volume, surfaces in mesh.surfaces_from_volume.items():
             if volume not in self._volumes_to_hide:
-                _visible_surfaces |= surfaces
+                _visible_surfaces |= set(surfaces)
 
         _visible_surfaces -= self._surfaces_to_hide
         return _visible_surfaces
@@ -34,18 +34,32 @@ class EntityVisibilityHandler(QObject):
 
         all_surfaces = mesh.all_surface_ids()
         return all_surfaces - self.get_visible_surfaces()
+    
+    def get_hidden_volumes(self) -> set[int]:
+        return set(self._volumes_to_hide)
+    
+    def get_visible_volumes(self) -> set[int]:
+        mesh = self.project.mesh
+        if mesh is None:
+            return set()
+
+        all_volumes = mesh.all_solid_ids()
+        return all_volumes - self.get_hidden_volumes()
 
     def hide_surfaces(self, surfaces: Sequence[int]):
         self._surfaces_to_hide |= set(surfaces)
-        if surfaces:
-            self.changed.emit()
+        # if surfaces:
+        #     self.changed.emit()
 
     def hide_volumes(self, volumes: Sequence[int]):
         self._volumes_to_hide |= set(volumes)
-        if volumes:
-            self.changed.emit()
+        # if volumes:
+        #     self.changed.emit()
+
+    def has_hidden_entity(self) -> bool:
+        return bool(self._surfaces_to_hide) or bool(self._volumes_to_hide)
 
     def unhide_all(self):
         self._surfaces_to_hide.clear()
         self._volumes_to_hide.clear()
-        self.changed.emit()
+        # self.changed.emit()

--- a/vibra/interface/general/entity_visibility_handler.py
+++ b/vibra/interface/general/entity_visibility_handler.py
@@ -62,6 +62,10 @@ class EntityVisibilityHandler(QObject):
         return bool(self._surfaces_to_hide) or bool(self._volumes_to_hide)
 
     def unhide_all(self):
+        # This is only to avoid unnecessary callbacks
+        if not any((self._surfaces_to_hide, self._volumes_to_hide)):
+            return
+
         self._surfaces_to_hide.clear()
         self._volumes_to_hide.clear()
         self.changed.emit()

--- a/vibra/interface/general/entity_visibility_handler.py
+++ b/vibra/interface/general/entity_visibility_handler.py
@@ -9,6 +9,8 @@ class EntityVisibilityHandler(QObject):
     changed = Signal()
 
     def __init__(self, project: Project):
+        super().__init__()
+
         self.project = project
 
         self._surfaces_to_hide = set()
@@ -48,13 +50,13 @@ class EntityVisibilityHandler(QObject):
 
     def hide_surfaces(self, surfaces: Sequence[int]):
         self._surfaces_to_hide |= set(surfaces)
-        # if surfaces:
-        #     self.changed.emit()
+        if surfaces:
+            self.changed.emit()
 
     def hide_volumes(self, volumes: Sequence[int]):
         self._volumes_to_hide |= set(volumes)
-        # if volumes:
-        #     self.changed.emit()
+        if volumes:
+            self.changed.emit()
 
     def has_hidden_entity(self) -> bool:
         return bool(self._surfaces_to_hide) or bool(self._volumes_to_hide)
@@ -62,4 +64,4 @@ class EntityVisibilityHandler(QObject):
     def unhide_all(self):
         self._surfaces_to_hide.clear()
         self._volumes_to_hide.clear()
-        # self.changed.emit()
+        self.changed.emit()

--- a/vibra/interface/general/selection_handler.py
+++ b/vibra/interface/general/selection_handler.py
@@ -17,6 +17,18 @@ class SelectionHandler(QObject):
         self.geometry_volumes = set()
         self.volume_selection_mode = False
 
+    @property
+    def surface_of_selected_volumes(self):
+        mesh = self.project.mesh
+        if mesh is None:
+            return set()
+
+        surfaces = set()
+        for volume in self.geometry_volumes:
+            surfaces |= set(mesh.surfaces_from_volume.get(volume, []))
+        
+        return surfaces
+
     def clear_selection(self):
         self.set_geometry_selection()
         self.set_mesh_selection()
@@ -33,11 +45,6 @@ class SelectionHandler(QObject):
 
         if volumes is None:
             volumes = set()
-
-        # Select the surfaces associated to the selected volumes
-        for volume in volumes:
-            volume_surfaces = self.project.model.mesh.surfaces_from_volume.get(volume, [])
-            surfaces |= set(volume_surfaces)
 
         if join and remove:
             self.geometry_points ^= set(points)

--- a/vibra/interface/general/selection_handler.py
+++ b/vibra/interface/general/selection_handler.py
@@ -150,3 +150,75 @@ class SelectionHandler(QObject):
                 new_mesh_selection["solids"] = mesh.all_solid_element_ids() - self.mesh_solids
             if new_mesh_selection:
                 self.set_mesh_selection(**new_mesh_selection)
+
+    def select_all_points(self):
+        mesh = self.project.model.mesh
+        if mesh is None:
+            return
+
+        self.set_geometry_selection(points=mesh.all_point_ids())
+
+    def select_all_lines(self):
+        mesh = self.project.model.mesh
+        if mesh is None:
+            return
+
+        self.set_geometry_selection(lines=mesh.all_line_ids())
+
+    def select_all_surfaces(self):
+        mesh = self.project.model.mesh
+        if mesh is None:
+            return
+
+        self.set_geometry_selection(surfaces=mesh.all_surface_ids())
+
+    def select_all_volumes(self):
+        mesh = self.project.model.mesh
+        if mesh is None:
+            return
+
+        self.set_geometry_selection(volumes=mesh.all_solid_ids())
+
+    def select_all_geometry(self):
+        mesh = self.project.model.mesh
+        if mesh is None:
+            return
+
+        self.set_geometry_selection(
+            points=mesh.all_point_ids(),
+            lines=mesh.all_line_ids(),
+            surfaces=mesh.all_surface_ids(),
+            volumes=mesh.all_solid_ids(),
+        )
+
+    def select_all_nodes(self):
+        mesh = self.project.model.mesh
+        if mesh is None:
+            return
+
+        self.set_mesh_selection(nodes=mesh.all_node_ids())
+
+    def select_all_faces(self):
+        mesh = self.project.model.mesh
+        if mesh is None:
+            return
+
+        self.set_mesh_selection(faces=mesh.all_face_element_ids())
+
+    def select_all_solids(self):
+        mesh = self.project.model.mesh
+        if mesh is None:
+            return
+
+        self.set_mesh_selection(solids=mesh.all_solid_element_ids())
+
+    def select_all_mesh(self):
+        mesh = self.project.model.mesh
+        if mesh is None:
+            return
+
+        self.set_mesh_selection(
+            nodes=mesh.all_node_ids(),
+            faces=mesh.all_face_element_ids(),
+            solids=mesh.all_solid_element_ids(),
+        )

--- a/vibra/interface/general/selection_handler.py
+++ b/vibra/interface/general/selection_handler.py
@@ -1,10 +1,11 @@
-from PySide6.QtCore import Signal, QObject
+from PySide6.QtCore import QObject, Signal
 
 from vibra.engine.project import Project
 
+
 class SelectionHandler(QObject):
     selection_changed = Signal()
-    
+
     def __init__(self, project: Project):
         super().__init__()
         self.project = project
@@ -26,7 +27,7 @@ class SelectionHandler(QObject):
         surfaces = set()
         for volume in self.geometry_volumes:
             surfaces |= set(mesh.surfaces_from_volume.get(volume, []))
-        
+
         return surfaces
 
     def clear_selection(self):
@@ -107,17 +108,21 @@ class SelectionHandler(QObject):
     def invert_selection(self):
         mesh = self.project.model.mesh
 
-        geometry_selection_active = any([
-            self.geometry_points,
-            self.geometry_lines,
-            self.geometry_surfaces,
-            self.geometry_volumes,
-        ])
-        mesh_selection_active = any([
-            self.mesh_nodes,
-            self.mesh_faces,
-            self.mesh_solids,
-        ])
+        geometry_selection_active = any(
+            [
+                self.geometry_points,
+                self.geometry_lines,
+                self.geometry_surfaces,
+                self.geometry_volumes,
+            ]
+        )
+        mesh_selection_active = any(
+            [
+                self.mesh_nodes,
+                self.mesh_faces,
+                self.mesh_solids,
+            ]
+        )
 
         if not geometry_selection_active and not mesh_selection_active:
             return
@@ -145,19 +150,3 @@ class SelectionHandler(QObject):
                 new_mesh_selection["solids"] = mesh.all_solid_element_ids() - self.mesh_solids
             if new_mesh_selection:
                 self.set_mesh_selection(**new_mesh_selection)
-
-    def calculate_volumes_to_hide(self):
-        volumes_to_hide = set()
-        if self.geometry_volumes:
-            volumes_to_hide |= self.geometry_volumes
-
-        elif self.geometry_surfaces:
-            for surface in self.geometry_surfaces:
-                volumes_to_hide |= set(self.project.model.mesh.volumes_from_surface[surface])
-
-        elif self.mesh_solids:
-            for element in self.mesh_solids:
-                volumes_to_hide.add(self.project.model.mesh.get_volume_from_element(element))
-        return volumes_to_hide
-
-

--- a/vibra/interface/general/selection_handler.py
+++ b/vibra/interface/general/selection_handler.py
@@ -17,9 +17,6 @@ class SelectionHandler(QObject):
         self.geometry_volumes = set()
         self.volume_selection_mode = False
 
-        self.hidden_surfaces = set()
-        self.hidden_volumes = set()
-
     def clear_selection(self):
         self.set_geometry_selection()
         self.set_mesh_selection()
@@ -36,9 +33,6 @@ class SelectionHandler(QObject):
 
         if volumes is None:
             volumes = set()
-
-        surfaces = set(surfaces) - set(self.hidden_surfaces)
-        volumes = set(volumes) - set(self.hidden_volumes)
 
         # Select the surfaces associated to the selected volumes
         for volume in volumes:

--- a/vibra/interface/main_window.py
+++ b/vibra/interface/main_window.py
@@ -604,12 +604,6 @@ class MainWindow(MainWindow_UI):
         self.entity_visibility.hide_volumes(self.selection.geometry_volumes)
         self.selection.clear_selection()
 
-    def recompute_hidden_volumes(self):
-        pass
-
-    def hide_volumes(self, volumes: set[int]):
-        self.entity_visibility.hide_volumes(volumes)
-
     def has_hidden_part(self) -> bool:
         return any(
             [

--- a/vibra/interface/main_window.py
+++ b/vibra/interface/main_window.py
@@ -374,45 +374,36 @@ class MainWindow(MainWindow_UI):
         self.render_user_preferences = RendererUserPreferencesInput()
 
     def action_points_callback(self):
-        all_ids = app().project.model.mesh.all_point_ids()
-        self.selection.set_geometry_selection(points=all_ids)
+        self.selection.select_all_points()
+        self.action_model_workspace_callback()
 
     def action_faces_callback(self):
-        all_ids = app().project.model.mesh.all_surface_ids()
-        self.selection.set_geometry_selection(surfaces=all_ids)
+        self.selection.select_all_surfaces()
+        self.action_model_workspace_callback()
 
     def action_solid_callback(self):
-        all_ids = app().project.model.mesh.all_solid_ids()
-        self.selection.set_geometry_selection(volumes=all_ids)
+        self.selection.select_all_volumes()
+        self.action_model_workspace_callback()
 
     def action_all_entities_geometry_callback(self):
-        mesh = app().project.model.mesh
-        self.selection.set_geometry_selection(
-            points=mesh.all_point_ids(),
-            lines=mesh.all_line_ids(),
-            surfaces=mesh.all_surface_ids(),
-            volumes=mesh.all_solid_ids(),
-        )
+        self.selection.select_all_geometry()
+        self.action_model_workspace_callback()
 
     def action_all_entities_mesh_callback(self):
-        mesh = app().project.model.mesh
-        self.selection.set_mesh_selection(
-            nodes=mesh.all_node_ids(),
-            faces=mesh.all_face_element_ids(),
-            solids=mesh.all_solid_element_ids(),
-        )
+        self.selection.select_all_mesh()
+        self.action_mesh_workspace_callback()
 
     def action_nodes_callback(self):
-        all_ids = app().project.model.mesh.all_node_ids()
-        self.selection.set_mesh_selection(nodes=all_ids)
+        self.selection.select_all_nodes()
+        self.action_mesh_workspace_callback()
 
     def action_surface_elements_callback(self):
-        all_ids = app().project.model.mesh.all_face_element_ids()
-        self.selection.set_mesh_selection(faces=all_ids)
+        self.selection.select_all_faces()
+        self.action_mesh_workspace_callback()
 
     def action_solid_elements_callback(self):
-        all_ids = app().project.model.mesh.all_solid_element_ids()
-        self.selection.set_mesh_selection(solids=all_ids)
+        self.selection.select_all_solids()
+        self.action_mesh_workspace_callback()
 
     def action_clear_selection_callback(self):
         self.selection.clear_selection()

--- a/vibra/interface/main_window.py
+++ b/vibra/interface/main_window.py
@@ -610,7 +610,6 @@ class MainWindow(MainWindow_UI):
 
     def hide_volumes(self, volumes: set[int]):
         self.entity_visibility.hide_volumes(volumes)
-        self.update_hidden_plots()
 
     def has_hidden_part(self) -> bool:
         return any(
@@ -636,7 +635,6 @@ class MainWindow(MainWindow_UI):
 
     def action_unhide_all_callback(self):
         self.entity_visibility.unhide_all()
-        self.update_hidden_plots()
 
     def action_save_callback(self):
         self.save_project_dialog()

--- a/vibra/interface/main_window.py
+++ b/vibra/interface/main_window.py
@@ -17,12 +17,13 @@ from vibra.engine.assemblers import AcousticAssembler
 from vibra.engine.solvers import HarmonicSolver
 from vibra.interface.data_handler.export_mesh_data import ExportMeshData
 from vibra.interface.formatters.icons import change_icon_color_for_widgets, get_vibra_icon
-from vibra.interface.model_inputs.general.choose_property_to_delete import ChoosePropertyToDelete
+from vibra.interface.general.entity_visibility_handler import EntityVisibilityHandler
 from vibra.interface.general.print_message_input import PrintMessageInput
 from vibra.interface.general.selection_handler import SelectionHandler
 from vibra.interface.loading_window import LoadingWindow
 from vibra.interface.menus.model_setup_widget import ModelSetupWidget
 from vibra.interface.menus.results_viewer_widget import ResultsViewerWidget
+from vibra.interface.model_inputs.general.choose_property_to_delete import ChoosePropertyToDelete
 from vibra.interface.model_inputs.general.mesher_setup_inputs import MesherSetupInputs
 from vibra.interface.plots.acoustic.export_element_transfer_data_inputs import ExportElementTransferDataInputs
 from vibra.interface.project.save_project_data_selector import SaveProjectDataSelector
@@ -31,8 +32,8 @@ from vibra.interface.status_bar import StatusBar
 from vibra.interface.toolbars.analysis_toolbar import AnalysisToolbar
 from vibra.interface.toolbars.view_toolbar import ViewToolbar
 from vibra.interface.ui_generated.main_window_ui import MainWindow_UI
-from vibra.interface.user_input.input_ui import InputUi
 from vibra.interface.user_input.about_vibra import AboutVibraInput
+from vibra.interface.user_input.input_ui import InputUi
 from vibra.interface.user_input.render_user_preferences import RendererUserPreferencesInput
 from vibra.interface.viewer_3d.render_widgets import GeometryRenderWidget, MeshRenderWidget, ResultsRenderWidget
 from vibra.interface.welcome_widget import WelcomeWidget
@@ -49,7 +50,10 @@ class MainWindow(MainWindow_UI):
         super().__init__(parent)
 
         self.selection = SelectionHandler(app().project)
+        self.entity_visibility = EntityVisibilityHandler(app().project)
+
         self.selection.selection_changed.connect(self.selection_changed_callback)
+        # self.entity_visibility.changed.connect(self.update_hidden_plots)
 
         self.hidden_mesh_faces = set()
         self.hidden_mesh_solids = set()
@@ -602,31 +606,16 @@ class MainWindow(MainWindow_UI):
         self.selection.clear_selection()
 
     def recompute_hidden_volumes(self):
-        self.selection.hidden_surfaces.clear()
-        self.hide_volumes(app().main_window.selection.hidden_volumes)
+        pass
 
     def hide_volumes(self, volumes: set[int]):
-        mesh = app().project.model.mesh
-
-        volumes = set(volumes)
-        selected_volume_surfaces = set()
-        visible_volume_surfaces = set()
-
-        for volume, surfaces in mesh.surfaces_from_volume.items():
-            if volume in volumes:
-                selected_volume_surfaces |= set(surfaces)
-            elif volume not in self.selection.hidden_volumes:
-                visible_volume_surfaces |= set(surfaces)
-        surfaces_to_keep_visible = set.intersection(selected_volume_surfaces, visible_volume_surfaces)
-
-        self.selection.hidden_volumes |= volumes
-        self.selection.hidden_surfaces |= selected_volume_surfaces - surfaces_to_keep_visible
+        self.entity_visibility.hide_volumes(volumes)
         self.update_hidden_plots()
 
     def has_hidden_part(self) -> bool:
         return any(
             [
-                len(self.selection.hidden_surfaces) != 0,
+                self.entity_visibility.has_hidden_entity(),
                 len(self.distinguished_solids) != 0,
                 self.section_plane.cutting,
                 bool(app().project.model.mesh.collapsed_elements_data),
@@ -646,8 +635,7 @@ class MainWindow(MainWindow_UI):
         self.visualization_changed.emit()
 
     def action_unhide_all_callback(self):
-        self.selection.hidden_surfaces.clear()
-        self.selection.hidden_volumes.clear()
+        self.entity_visibility.unhide_all()
         self.update_hidden_plots()
 
     def action_save_callback(self):

--- a/vibra/interface/main_window.py
+++ b/vibra/interface/main_window.py
@@ -326,11 +326,12 @@ class MainWindow(MainWindow_UI):
         self.last_render_index = new_index
 
     def selection_changed_callback(self):
-        points = self.selection.geometry_points
-        lines = self.selection.geometry_lines
-        surfaces = self.selection.geometry_surfaces
-        volumes = self.selection.geometry_volumes
-        self.status_bar.set_selection(points, lines, surfaces, volumes)
+        self.status_bar.set_selection(
+            self.selection.geometry_points,
+            self.selection.geometry_lines,
+            self.selection.geometry_surfaces,
+            self.selection.geometry_volumes,
+        )
 
     def action_section_plane_callback(self, condition: bool):
         if condition:

--- a/vibra/interface/main_window.py
+++ b/vibra/interface/main_window.py
@@ -600,9 +600,8 @@ class MainWindow(MainWindow_UI):
                 ]
             )
 
-        volumes_to_hide = self.selection.calculate_volumes_to_hide()
-
-        self.hide_volumes(volumes_to_hide)
+        self.entity_visibility.hide_surfaces(self.selection.geometry_surfaces)
+        self.entity_visibility.hide_volumes(self.selection.geometry_volumes)
         self.selection.clear_selection()
 
     def recompute_hidden_volumes(self):

--- a/vibra/interface/main_window.py
+++ b/vibra/interface/main_window.py
@@ -53,7 +53,7 @@ class MainWindow(MainWindow_UI):
         self.entity_visibility = EntityVisibilityHandler(app().project)
 
         self.selection.selection_changed.connect(self.selection_changed_callback)
-        # self.entity_visibility.changed.connect(self.update_hidden_plots)
+        self.entity_visibility.changed.connect(self.update_hidden_plots)
 
         self.hidden_mesh_faces = set()
         self.hidden_mesh_solids = set()

--- a/vibra/interface/model_inputs/acoustic/internal_impedances/perforated_plate_model_inputs.py
+++ b/vibra/interface/model_inputs/acoustic/internal_impedances/perforated_plate_model_inputs.py
@@ -980,9 +980,6 @@ class PerforatedPlateModelInputs(PerforatedPlateModelInputs_UI):
             logging.info("Processing the post-assignment actions... [60/100]")
             app().project.update_model_properties_file()
 
-            logging.info("Processing the post-assignment actions... [70/100]")
-            app().main_window.recompute_hidden_volumes()
-
             logging.info("Processing the post-assignment actions... [80/100]")
             app().main_window.update_info_text()
 
@@ -1018,7 +1015,6 @@ class PerforatedPlateModelInputs(PerforatedPlateModelInputs_UI):
         
             logging.info("Processing degress of freedom decoupling... [95/100]")
             app().main_window.update_plots()
-            app().main_window.recompute_hidden_volumes()
 
         LoadingWindow(callback).run()
 

--- a/vibra/interface/model_inputs/acoustic/internal_impedances/transfer_impedance_inputs.py
+++ b/vibra/interface/model_inputs/acoustic/internal_impedances/transfer_impedance_inputs.py
@@ -676,9 +676,6 @@ class TransferImpedanceInputs(TransferImpedanceInputs_UI):
             logging.info("Processing the post-assignment actions... [60/100]")
             app().project.update_model_properties_file()
 
-            logging.info("Processing the post-assignment actions... [70/100]")
-            app().main_window.recompute_hidden_volumes()
-
             logging.info("Processing the post-assignment actions... [80/100]")
             app().main_window.update_info_text()
 

--- a/vibra/interface/model_inputs/dof_decoupling/degrees_of_freedom_decoupling_inputs.py
+++ b/vibra/interface/model_inputs/dof_decoupling/degrees_of_freedom_decoupling_inputs.py
@@ -242,9 +242,6 @@ class DegreesOfFreedomDecouplingInputs(DegreesOfFreedomDecouplingInputs_UI):
             logging.info("Processing the post-assignment actions... [60/100]")
             app().project.update_model_properties_file()
 
-            logging.info("Processing the post-assignment actions... [70/100]")
-            app().main_window.recompute_hidden_volumes()
-
             logging.info("Processing the post-assignment actions... [80/100]")
             app().main_window.update_info_text()
 

--- a/vibra/interface/model_inputs/structural/surface_thickness_inputs.py
+++ b/vibra/interface/model_inputs/structural/surface_thickness_inputs.py
@@ -281,13 +281,10 @@ class SurfaceThicknessInputs(SurfaceThicknessInputs_UI):
                 surfaces_to_hide.append(surface_id)
 
         if surfaces_to_hide:
-
             if len(surface_ids) == len(surfaces_to_hide):
                 return
 
-            for _surface_id in surfaces_to_hide:
-                app().main_window.selection.hidden_surfaces.add(_surface_id)
-    
+            app().main_window.entity_visibility.hide_surfaces(surfaces_to_hide)    
             app().main_window.update_hidden_plots()
 
     def keyPressEvent(self, event):

--- a/vibra/interface/model_inputs/structural/surface_thickness_inputs.py
+++ b/vibra/interface/model_inputs/structural/surface_thickness_inputs.py
@@ -285,7 +285,6 @@ class SurfaceThicknessInputs(SurfaceThicknessInputs_UI):
                 return
 
             app().main_window.entity_visibility.hide_surfaces(surfaces_to_hide)    
-            app().main_window.update_hidden_plots()
 
     def keyPressEvent(self, event):
         if event.key() == Qt.Key_Enter or event.key() == Qt.Key_Return:

--- a/vibra/interface/viewer_3d/actors/faces_actor.py
+++ b/vibra/interface/viewer_3d/actors/faces_actor.py
@@ -103,7 +103,10 @@ class FacesActor(vtkActor):
                 surface_to_volume[surface] = volume
 
         self.visible_indexes = dict()
-        hidden_surfaces = app().main_window.selection.hidden_surfaces if self.allow_hidding else set()
+        hidden_surfaces = app().main_window.entity_visibility.get_hidden_surfaces()
+        if not self.allow_hidding:
+            hidden_surfaces.clear()
+
         for i, surface, _, _, *values in self.mesh.faces_connectivity:
             if surface in hidden_surfaces:
                 continue

--- a/vibra/interface/viewer_3d/actors/multimaterial.py
+++ b/vibra/interface/viewer_3d/actors/multimaterial.py
@@ -32,7 +32,7 @@ from vibra.utils.vtk_utils import fill_array, read_texture
 
 def get_first_visible_volume(volumes):
     for volume in volumes:
-        if volume not in app().main_window.selection.hidden_volumes:
+        if volume not in app().main_window.entity_visibility._volumes_to_hide:
             return volume
 
 
@@ -118,12 +118,11 @@ class MultimaterialGeometryActor(vtkPropAssembly):
         properties = app().project.model.properties
         color_mode = self.visualization_filter.color_mode
         surfaces = mesh.lines_from_surface.keys()  # We don't have just "surfaces" yet
+        visible_surfaces = app().main_window.entity_visibility.get_visible_surfaces()
 
         if color_mode == GeometryColorMode.EMPTY:
             self.clear_composition()
             self.default_actor.VisibilityOn()
-            hidden_surfaces = app().main_window.selection.hidden_surfaces
-            visible_surfaces = set(surfaces) - hidden_surfaces
             self.configure_composition("default", visible_surfaces)
             return
 
@@ -135,10 +134,10 @@ class MultimaterialGeometryActor(vtkPropAssembly):
             volumes = mesh.volumes_from_surface.get(surface, ())
             volume = get_first_visible_volume(volumes)
 
-            if surface in app().main_window.selection.hidden_surfaces:
-                continue
-            else:
+            if surface in visible_surfaces:
                 composition_to_surfaces["default"].append(surface)
+            else:
+                continue
 
             fluid = properties._get_property("fluid", surface=surface, volume=volume)
             material_wall = properties._get_property("material", surface=surface)
@@ -231,8 +230,10 @@ class MultimaterialGeometryActor(vtkPropAssembly):
 
     def _create_surfaces(self):
         combined_surfaces = vtkAppendPolyData()
+        visible_surfaces = app().main_window.entity_visibility.get_visible_surfaces()
+
         for surface, elements in self.mesh.elements_from_surface.items():
-            if surface in app().main_window.selection.hidden_surfaces:
+            if surface not in visible_surfaces:
                 continue
 
             coords, connect = self._reduce_connectivity(

--- a/vibra/interface/viewer_3d/actors/solids_actor.py
+++ b/vibra/interface/viewer_3d/actors/solids_actor.py
@@ -95,7 +95,7 @@ class SolidsActor(vtkActor):
         coordinates = self.get_coordinates()
         points.SetData(numpy_to_vtk(coordinates))
 
-        hidden_volumes = app().main_window.selection.hidden_volumes if self.allow_hidding else set()
+        hidden_volumes = app().main_window.entity_visibility.get_hidden_volumes()
         self.visible_indexes = dict()
 
         for i, volume, _, _, *nodes in nodes_connectivity:

--- a/vibra/interface/viewer_3d/render_widgets/geometry_render_widget.py
+++ b/vibra/interface/viewer_3d/render_widgets/geometry_render_widget.py
@@ -1,5 +1,5 @@
-from vibra.utils.time_utils import warn_delays
 import logging
+from datetime import datetime
 
 from molde import Color
 from molde.render_widgets import CommonRenderWidget
@@ -9,6 +9,7 @@ from PySide6.QtWidgets import QApplication
 from vibra import ICON_DIR, app
 from vibra.utils.image_functions import removes_image_background
 from vibra.utils.interface_utils import VisualizationFilter
+from vibra.utils.time_utils import warn_delays
 
 from ..actors.ghost_actor import GhostActor
 from ..actors.lines_actor import LinesActor
@@ -44,6 +45,8 @@ class GeometryRenderWidget(CommonRenderWidget):
 
         self.geometry_selection = GeometrySelection(self)
         self.mouse_click = (0, 0)
+        self.last_click_time: datetime | None = None
+        self.is_double_click = False
 
         self.left_clicked.connect(self.click_callback)
         self.left_released.connect(self.selection_callback)
@@ -294,6 +297,13 @@ class GeometryRenderWidget(CommonRenderWidget):
     def click_callback(self, x, y):
         self.mouse_click = (x, y)
 
+        self.is_double_click = False
+        current_click_time = datetime.now()
+        if self.last_click_time is not None:
+            time_since_last_click = (current_click_time - self.last_click_time).total_seconds()
+            self.is_double_click = time_since_last_click < 0.5
+        self.last_click_time = current_click_time
+
     @warn_delays(0.2)  # this is already too much and should be optimized
     def selection_callback(self, x, y):
         if not self.actors_exists():
@@ -339,7 +349,7 @@ class GeometryRenderWidget(CommonRenderWidget):
         shift_pressed = modifiers & Qt.ShiftModifier
         alt_pressed = modifiers & Qt.AltModifier
 
-        if not (shift_pressed or app().main_window.selection.volume_selection_mode):
+        if not (self.is_double_click or shift_pressed or app().main_window.selection.volume_selection_mode):
             picked_volumes.clear()
 
         app().main_window.selection.set_geometry_selection(

--- a/vibra/interface/viewer_3d/render_widgets/geometry_render_widget.py
+++ b/vibra/interface/viewer_3d/render_widgets/geometry_render_widget.py
@@ -348,8 +348,16 @@ class GeometryRenderWidget(CommonRenderWidget):
         ctrl_pressed = modifiers & Qt.ControlModifier
         shift_pressed = modifiers & Qt.ShiftModifier
         alt_pressed = modifiers & Qt.AltModifier
+    
+        select_volume = any([
+            self.is_double_click,
+            shift_pressed,
+            app().main_window.selection.volume_selection_mode
+        ])
 
-        if not (self.is_double_click or shift_pressed or app().main_window.selection.volume_selection_mode):
+        if select_volume:
+            picked_surfaces.clear()
+        else:
             picked_volumes.clear()
 
         app().main_window.selection.set_geometry_selection(
@@ -373,7 +381,7 @@ class GeometryRenderWidget(CommonRenderWidget):
 
         points = app().main_window.selection.geometry_points
         lines = app().main_window.selection.geometry_lines
-        surfaces = app().main_window.selection.geometry_surfaces
+        surfaces = app().main_window.selection.geometry_surfaces | app().main_window.selection.surface_of_selected_volumes
 
         self.points_actor.paint_points(self.selection_nodes_points_color, points)
         self.lines_actor.paint_lines(self.selection_lines_color, lines)

--- a/vibra/utils/interface_utils.py
+++ b/vibra/utils/interface_utils.py
@@ -2,6 +2,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from enum import IntEnum, auto
 from functools import partial, wraps
+from typing import Generator, TypeVar
 
 import numpy as np
 from PySide6.QtCore import QTimer
@@ -42,8 +43,11 @@ class VisualizationFilter:
         return cls(*args)
 
 
+T = TypeVar("T", bound=QWidget)
+
+
 @contextmanager
-def block_signals(widget: QWidget):
+def block_signals(widget: T) -> Generator[T, None, None]:
     widget.blockSignals(True)
     try:
         yield widget


### PR DESCRIPTION
This PR moves methods and properties related to hiding showing entities to a new class named EntityVisibilityHandler.
A few methods related to selection were also moved to the existing SelectionHandler.

Besides the refactoring, it now allows the user to hide single surfaces and select volumes by double clicking them.