### PR TITLE
Clears the stylesheet of the line edits correctly

### DIFF
--- a/vibra/interface/analysis/harmonic_analysis_setup_input.py
+++ b/vibra/interface/analysis/harmonic_analysis_setup_input.py
@@ -16,9 +16,10 @@ from vibra.interface import error_title
 from vibra.interface.analysis.solutions_step_display_input import SolutionStepsDisplayInput
 from vibra.interface.analysis.user_defined_solution_steps_by_manual_input import UserDefinedSolutionStepsByManualInput
 from vibra.interface.analysis.user_defined_solution_steps_from_tabular_data_input import UserDefinedSolutionStepsFromTabularDataInput
-from vibra.interface.common.common_interface import check_mesh_related_issues#, mesher_interface_callback
+from vibra.interface.common.common_interface import check_mesh_related_issues  #, mesher_interface_callback
 from vibra.interface.general.get_user_confirmation_input import GetUserConfirmationInput
 from vibra.interface.general.print_message_input import PrintMessageInput
+from vibra.interface.general.utils import clear_style_sheet
 from vibra.interface.numeric_checks.double_validator import StrictDoubleValidator
 from vibra.interface.ui_generated.analysis.harmonic_analysis_setup_input_ui import HarmonicAnalysisSetupInput_UI
 
@@ -352,9 +353,8 @@ class HarmonicAnalysisSetupInput(HarmonicAnalysisSetupInput_UI):
                 self.lineEdit_fmax.setFocus()
                 self.lineEdit_fmax.setStyleSheet("border-color: rgb(255,0,0); border-width: 2px")
                 return True
-            
-        self.lineEdit_fmin.setStyleSheet("")
-        self.lineEdit_fmax.setStyleSheet("")
+
+        clear_style_sheet([self.lineEdit_fmin, self.lineEdit_fmax])
 
         return False
 

--- a/vibra/interface/general/utils.py
+++ b/vibra/interface/general/utils.py
@@ -1,0 +1,11 @@
+from PySide6.QtWidgets import QWidget
+
+
+def clear_style_sheet(widgets: QWidget | list[QWidget]):
+    if isinstance(widgets, QWidget):
+        widgets = [widgets]
+
+    for widget in widgets:
+        widget.setStyleSheet("")
+        widget.style().unpolish(widget)
+        widget.style().polish(widget)

--- a/vibra/interface/model_inputs/acoustic/acoustic_properties_gradient_inputs.py
+++ b/vibra/interface/model_inputs/acoustic/acoustic_properties_gradient_inputs.py
@@ -5,6 +5,7 @@ from PySide6.QtWidgets import QLineEdit
 
 from vibra import app
 from vibra.engine.properties.fluid import Fluid
+from vibra.interface.general.utils import clear_style_sheet
 
 # from vibra.interface import error_title, warning_title
 from vibra.interface.model_inputs.fluid.set_fluid_inputs_simplified import SetFluidInputsSimplified
@@ -160,18 +161,9 @@ class AcousticPropertiesGradientInputs(AcousticPropertiesGradientInputs_UI):
         self.highlight_line_edit()
 
     def highlight_line_edit(self):
+        line_edits = [self.lineEdit_end_coords, self.lineEdit_selection_id, self.lineEdit_start_coords]
+        clear_style_sheet([line_edit for line_edit in line_edits if line_edit is not self.current_line_edit])
         self.current_line_edit.setStyleSheet("border-color: rgb(255,0,0); border-width: 2px")
-        if self.current_line_edit == self.lineEdit_start_coords:
-            self.lineEdit_end_coords.setStyleSheet("")
-            self.lineEdit_selection_id.setStyleSheet("")
-        elif self.current_line_edit == self.lineEdit_end_coords:
-            self.lineEdit_start_coords.setStyleSheet("")
-            self.lineEdit_selection_id.setStyleSheet("")
-        elif self.current_line_edit == self.lineEdit_selection_id:
-            self.lineEdit_start_coords.setStyleSheet("")
-            self.lineEdit_end_coords.setStyleSheet("")
-        else:
-            pass
 
     def attribution_type_callback(self):
 

--- a/vibra/interface/model_inputs/acoustic/acoustic_transfer_element_inputs.py
+++ b/vibra/interface/model_inputs/acoustic/acoustic_transfer_element_inputs.py
@@ -13,6 +13,7 @@ from vibra.engine.analysis_info import AnalysisID, FrequencySpacing, HarmonicAna
 from vibra.interface import error_title
 from vibra.interface.common.common_interface import mesher_interface_callback
 from vibra.interface.general.print_message_input import PrintMessageInput
+from vibra.interface.general.utils import clear_style_sheet
 from vibra.interface.loading_window import LoadingWindow
 from vibra.interface.numeric_checks.double_validator import StrictDoubleValidator
 from vibra.interface.ui_generated.model.acoustic.element_transfer.acoustic_transfer_element_inputs_ui import AcousticTransferElementInputs_UI
@@ -137,11 +138,9 @@ class AcousticTransferElementInputs(AcousticTransferElementInputs_UI):
         self.highlight_line_edit()
 
     def highlight_line_edit(self):
+        line_edits = [self.lineEdit_input_selected_id, self.lineEdit_output_selected_id]
+        clear_style_sheet([line_edit for line_edit in line_edits if line_edit is not self.current_line_edit])
         self.current_line_edit.setStyleSheet(self.highlight_style_sheet)
-        if self.current_line_edit == self.lineEdit_input_selected_id:
-            self.lineEdit_output_selected_id.setStyleSheet("")
-        elif self.current_line_edit == self.lineEdit_output_selected_id:
-            self.lineEdit_input_selected_id.setStyleSheet("")
 
     def _load_analysis_setup(self):
         analysis_setup = self.analysis_setup
@@ -219,7 +218,7 @@ class AcousticTransferElementInputs(AcousticTransferElementInputs_UI):
                 line_edit.setStyleSheet(self.highlight_style_sheet)
                 return True
 
-            line_edit.setStyleSheet("")
+            clear_style_sheet(line_edit)
             freq_data.append(float(line_edit.text()))
 
         [f_min, f_max, f_step] = freq_data

--- a/vibra/interface/model_inputs/acoustic/excitations/compressor_excitation_waveform_inputs.py
+++ b/vibra/interface/model_inputs/acoustic/excitations/compressor_excitation_waveform_inputs.py
@@ -17,6 +17,7 @@ from vibra.interface.data.data_manager import get_spectral_data_from_array
 from vibra.interface.data_handler.data_importer import DataImporter
 from vibra.interface.general.get_user_confirmation_input import GetUserConfirmationInput
 from vibra.interface.general.print_message_input import PrintMessageInput
+from vibra.interface.general.utils import clear_style_sheet
 from vibra.interface.plots.general.frequency_response_plotter import DataFormat, FrequencyResponsePlotter
 from vibra.interface.ui_generated.model.acoustic.excitations.compressor_excitation_waveform_inputs_ui import CompressorExcitationWaveformInputs_UI
 from vibra.utils.signal_processing import extend_signal, get_window_and_correction_factor, process_one_sided_spectrum
@@ -206,7 +207,7 @@ class CompressorExcitationWaveformInputs(CompressorExcitationWaveformInputs_UI):
             line_edit.setStyleSheet("""border-color: rgb(240, 10, 10); border-width: 2px;""")
             return None
 
-        line_edit.setStyleSheet("")
+        clear_style_sheet(line_edit)
 
         return value
 

--- a/vibra/interface/plots/acoustic/acoustic_frequency_response_function_inputs.py
+++ b/vibra/interface/plots/acoustic/acoustic_frequency_response_function_inputs.py
@@ -9,6 +9,7 @@ from vibra.engine import AnalysisID
 from vibra.engine.properties.fluid import Fluid
 from vibra.interface.data_handler.export_model_results import ExportModelResults
 from vibra.interface.general.print_message_input import PrintMessageInput
+from vibra.interface.general.utils import clear_style_sheet
 from vibra.interface.numeric_checks.double_validator import StrictDoubleValidator
 from vibra.interface.numeric_checks.unit_utilities import convert_length_unit, units_abreviations
 from vibra.interface.plots.general.frequency_response_plotter import FrequencyResponsePlotter
@@ -123,13 +124,9 @@ class AcousticPressureFrequencyResponseFunctionInputs(AcousticPressureFrequencyR
         self.highlight_selected_line_edit()
 
     def highlight_selected_line_edit(self):
-
-        if self.current_lineEdit == self.lineEdit_input_selected_id:
-            self.lineEdit_output_selected_id.setStyleSheet("")
-        else:
-            self.lineEdit_input_selected_id.setStyleSheet("")
-
-        self.current_lineEdit.setStyleSheet("""border-color: rgb(32, 207, 255); border-width: 2px;""")
+        line_edits = [self.lineEdit_input_selected_id, self.lineEdit_output_selected_id]
+        clear_style_sheet([line_edit for line_edit in line_edits if line_edit is not self.current_lineEdit])
+        self.current_lineEdit.setStyleSheet("border-color: rgb(32, 207, 255); border-width: 2px;")
 
     def alternate_selected_line_edit(self):
         if self.current_lineEdit == self.lineEdit_input_selected_id:

--- a/vibra/interface/plots/acoustic/acoustic_waves_decomposition_inputs.py
+++ b/vibra/interface/plots/acoustic/acoustic_waves_decomposition_inputs.py
@@ -9,6 +9,8 @@ from vibra.engine import AnalysisID
 from vibra.engine.properties.fluid import Fluid
 from vibra.interface.data_handler.export_model_results import ExportModelResults
 from vibra.interface.general.print_message_input import PrintMessageInput
+from vibra.interface.general.utils import clear_style_sheet
+
 # from vibra.interface.numeric_checks.int_list_validator import IntListValidator
 from vibra.interface.plots.general.frequency_response_plotter import FrequencyResponsePlotter
 from vibra.interface.ui_generated.plots.acoustic.acoustic_waves_decomposition_inputs_ui import AcousticWavesDecompositionInputs_UI
@@ -108,12 +110,8 @@ class AcousticWavesDecompositionInputs(AcousticWavesDecompositionInputs_UI):
         self.highlight_selected_line_edit()
 
     def highlight_selected_line_edit(self):
-
-        if self.current_lineEdit == self.lineEdit_input_selected_id:
-            self.lineEdit_output_selected_id.setStyleSheet("")
-        else:
-            self.lineEdit_input_selected_id.setStyleSheet("")
-
+        line_edits = [self.lineEdit_input_selected_id, self.lineEdit_output_selected_id]
+        clear_style_sheet([line_edit for line_edit in line_edits if line_edit is not self.current_lineEdit])
         self.current_lineEdit.setStyleSheet("""border-color: rgb(32, 207, 255); border-width: 2px;""")
 
     def alternate_selected_line_edit(self):

--- a/vibra/interface/plots/acoustic/transmission_loss_inputs.py
+++ b/vibra/interface/plots/acoustic/transmission_loss_inputs.py
@@ -11,6 +11,7 @@ from vibra.engine.properties.fluid import Fluid
 from vibra.interface import error_title
 from vibra.interface.data_handler.export_model_results import ExportModelResults
 from vibra.interface.general.print_message_input import PrintMessageInput
+from vibra.interface.general.utils import clear_style_sheet
 from vibra.interface.loading_window import LoadingWindow
 from vibra.interface.numeric_checks.double_validator import StrictDoubleValidator
 from vibra.interface.numeric_checks.unit_utilities import convert_length_unit, units_abreviations
@@ -123,11 +124,8 @@ class TransmissionLossInputs(TransmissionLossInputs_UI):
         self.highlight_selected_line_edit()
 
     def highlight_selected_line_edit(self):
-        if self.current_lineEdit == self.lineEdit_input_surface_id:
-            self.lineEdit_output_surface_id.setStyleSheet("")
-        else:
-            self.lineEdit_input_surface_id.setStyleSheet("")
-
+        line_edits = [self.lineEdit_input_surface_id, self.lineEdit_output_surface_id]
+        clear_style_sheet([line_edit for line_edit in line_edits if line_edit is not self.current_lineEdit])
         self.current_lineEdit.setStyleSheet("""border-color: rgb(32, 207, 255); border-width: 2px;""")
 
     def alternate_selected_line_edit(self):


### PR DESCRIPTION
## What does this PR do?

This PR fix a bug that started to happen with the line edits after an update of the PySide6 dependency. To fix it, I created a function called `clear_style_sheet`, in the `vibra/interface/general/utils.py` file, that clears and update the style sheet of a widget correctly.