### PR TITLE
Add pre-study penalization for allowable pulsation 3D plot

### DIFF
--- a/vibra/engine/mesher/degrees_of_freedom_decoupling_new.py
+++ b/vibra/engine/mesher/degrees_of_freedom_decoupling_new.py
@@ -171,18 +171,8 @@ class DegreesOfFreedomDecoupling:
 
         nodes_from_surfaces = list(nodes_from_surfaces)
 
-        self.map_nodes_to_volumes(nodes_from_surfaces)
-
-        count = 0
-        data = np.zeros((len(self.volumes_from_node), 2), dtype=int)
-
-        for node_id, vol_ids in self.volumes_from_node.items():
-            data[:, :] = [node_id, len(vol_ids)]
-            count += len(vol_ids)
-
-        np.savetxt("nodes_from_surface.dat", data, fmt="%i", delimiter=",")
-
-        print(f"Mapping nodes to volumes: {len(self.volumes_from_node)} {count} {len(nodes_from_surfaces)}")
+        # self.map_nodes_to_volumes()
+        # self.map_lines_to_decoupled_surfaces()
 
         # create the twin nodes indexes
         twin_nodes = np.arange(0, len(nodes_from_surfaces), dtype=int) + int(max_node_id) + 1
@@ -199,22 +189,54 @@ class DegreesOfFreedomDecoupling:
         self.mesh.nodal_coordinates = np.append(nodal_coordinates, coords_from_twin_nodes, axis=0)
 
 
-    def map_nodes_to_volumes(self, node_ids: list[int]):
-        volumes_to_decouple = list(self.decouple_info.values())
-        mask = np.any(np.isin(self.mesh.solids_connectivity[:, 4:], node_ids), axis=1)
-        for _, vol_id, _, _, *connect in self.mesh.solids_connectivity[mask, :]:
-            if vol_id not in volumes_to_decouple:
+    def map_nodes_to_volumes(self):
+
+        for surface_id, volume_to_decouple in self.decouple_info.items():
+            mask_2d = self.mesh.cache_faces_connectivity[:, 1] == surface_id
+            surface_nodes = np.unique(self.mesh.cache_faces_connectivity[mask_2d, 4:].flatten())
+            mask_3d = np.any(np.isin(self.mesh.cache_solids_connectivity[:, 4:], surface_nodes), axis=1)
+            for _, vol_id, _, _, *connect in self.mesh.cache_solids_connectivity[mask_3d, :]:
+                if vol_id != volume_to_decouple:
+                    continue
+
+                for node_id in connect:
+                    if node_id not in surface_nodes:
+                        continue
+
+                    if vol_id in self.volumes_from_node[node_id]:
+                        continue
+
+                    self.volumes_from_node[node_id].append(vol_id)
+
+                    count = 0
+
+        data = np.zeros((len(self.volumes_from_node), 2), dtype=int)
+
+        for i, (node_id, vol_ids) in enumerate(self.volumes_from_node.items()):
+            data[i, :] = [node_id, len(vol_ids)]
+            count += len(vol_ids)
+
+        # np.savetxt("nodes_from_surface.dat", data, fmt="%i", delimiter=",")
+
+
+    def map_lines_to_decoupled_surfaces(self):
+        lines_to_surface = defaultdict(int)
+        for surface in self.decouple_info:
+            for line_id in self.mesh.cache_lines_from_surface.get(surface):
+                lines_to_surface[line_id] += 1
+
+        n_duplicates = 0
+
+        for line_id, count in lines_to_surface.items():
+            if count <= 2:
                 continue
 
-            for node_id in connect:
-                if node_id not in node_ids:
-                    continue
+            mask = self.mesh.lines_connectivity[:, 1] == line_id
+            if not mask.any():
+                continue
 
-                node_volumes = self.volumes_from_node[node_id]
-                if vol_id in node_volumes:
-                    continue
-
-                node_volumes.append(vol_id)
+            line_nodes = np.unique(self.mesh.lines_connectivity[mask, 4:].flatten())
+            n_duplicates += line_nodes.size * (count - 1)
 
 
     def export_nodes_mapping(self):

--- a/vibra/engine/mesher/degrees_of_freedom_decoupling_new.py
+++ b/vibra/engine/mesher/degrees_of_freedom_decoupling_new.py
@@ -24,8 +24,8 @@ class DegreesOfFreedomDecoupling:
     def initialize(self):
         self.decouple_info = {}
         self.nodes_mapping = {}
+        self.volumes_from_node = defaultdict(list)
         self.volume_to_surfaces_map = defaultdict(list)
-
 
     def gathering_decoupling_information(self):
         """ This method gathers all existing decoupling 
@@ -34,6 +34,7 @@ class DegreesOfFreedomDecoupling:
         self.decouple_info.clear()
         self.nodes_mapping.clear()
         self.volume_to_surfaces_map.clear()
+        self.volumes_from_node.clear()
 
         if self.mesh.cache_nodal_coordinates is None:
             return
@@ -170,6 +171,19 @@ class DegreesOfFreedomDecoupling:
 
         nodes_from_surfaces = list(nodes_from_surfaces)
 
+        self.map_nodes_to_volumes(nodes_from_surfaces)
+
+        count = 0
+        data = np.zeros((len(self.volumes_from_node), 2), dtype=int)
+
+        for node_id, vol_ids in self.volumes_from_node.items():
+            data[:, :] = [node_id, len(vol_ids)]
+            count += len(vol_ids)
+
+        np.savetxt("nodes_from_surface.dat", data, fmt="%i", delimiter=",")
+
+        print(f"Mapping nodes to volumes: {len(self.volumes_from_node)} {count} {len(nodes_from_surfaces)}")
+
         # create the twin nodes indexes
         twin_nodes = np.arange(0, len(nodes_from_surfaces), dtype=int) + int(max_node_id) + 1
 
@@ -183,6 +197,24 @@ class DegreesOfFreedomDecoupling:
 
         # append the twin nodes data in the nodal coordinates matrix
         self.mesh.nodal_coordinates = np.append(nodal_coordinates, coords_from_twin_nodes, axis=0)
+
+
+    def map_nodes_to_volumes(self, node_ids: list[int]):
+        volumes_to_decouple = list(self.decouple_info.values())
+        mask = np.any(np.isin(self.mesh.solids_connectivity[:, 4:], node_ids), axis=1)
+        for _, vol_id, _, _, *connect in self.mesh.solids_connectivity[mask, :]:
+            if vol_id not in volumes_to_decouple:
+                continue
+
+            for node_id in connect:
+                if node_id not in node_ids:
+                    continue
+
+                node_volumes = self.volumes_from_node[node_id]
+                if vol_id in node_volumes:
+                    continue
+
+                node_volumes.append(vol_id)
 
 
     def export_nodes_mapping(self):

--- a/vibra/engine/mesher/mesh.py
+++ b/vibra/engine/mesher/mesh.py
@@ -1665,13 +1665,19 @@ class Mesh:
         if not print_log:
             return
 
-        if not self.disconnected_nodes_data:
-            return
-
-        print("\nThe following disconnected nodes have been detected:")
-
         for key, data in self.disconnected_nodes_data.items():
-            print(f">> {len(data)} nodes of {key}: {data[:10]}" + ", ..." if len(data) > 10 else "")
+            n_nodes = len(data)
+            if n_nodes == 0:
+                continue
+
+            nodes_list = data if n_nodes < 10 else data[:10]
+
+            message = f">> At least {n_nodes} disconnected nodes have been detected for {key}:\n"
+            message += f"Nodes list: {nodes_list}"
+            if n_nodes > 10:
+                message += ", ..."
+
+            print(message)
 
     def get_list_of_disconnected_nodes(self):
         """

--- a/vibra/engine/mesher/mesh.py
+++ b/vibra/engine/mesher/mesh.py
@@ -1421,8 +1421,6 @@ class Mesh:
 
     def process_mesh_related_mappings(self, label: str = "Loading"):
 
-        print("process_mesh_related_mappings")
-
         logging.info(f"{label} mesh... [70/100]")
         self.map_elements_from_volumes()
 
@@ -1543,10 +1541,6 @@ class Mesh:
             self.face_to_solid_element[e2d_id] = e3d_id
             self.solid_to_face_elements[e3d_id].append(e2d_id)
 
-        print(f"Map face to solid elements >>> {len(self.face_to_solid_element)}")
-        print(f"Number of surface elements >>> {len(self.faces_connectivity)}")
-        print(f"Difference: {len(self.faces_connectivity) - len(self.face_to_solid_element)}")
-
     def map_face_elements_to_solid_elements(self):
         """
         This method implements a faster algorithm when compared with
@@ -1597,13 +1591,16 @@ class Mesh:
             self.face_to_solid_element[face_id] = solid_id
             self.solid_to_face_elements[solid_id].append(face_id)
 
-        print(f"Number of surface elements >>> {len(self.faces_connectivity)}")
-        print(f"Map face to solid elements >>> {len(self.face_to_solid_element)}")
-        print(f"Difference: {len(self.faces_connectivity) - len(self.face_to_solid_element)}")
+        number_2d_elements = len(self.faces_connectivity)
+        elements_map_size = len(self.face_to_solid_element)
 
-        rows = np.isin(np.unique(self.faces_connectivity[:, 0].flatten()), list(self.face_to_solid_element.keys()), invert=True)
+        if number_2d_elements - elements_map_size:
+            print(f"Number of surface elements >>> {number_2d_elements}")
+            print(f"Map face to solid elements >>> {elements_map_size}")
+            print(f"Difference: {number_2d_elements - elements_map_size}")
 
-        np.savetxt("non_mapped_2d_elements.dat", self.faces_connectivity[rows, :], delimiter=",", fmt="%i")
+            # rows = np.isin(np.unique(self.faces_connectivity[:, 0].flatten()), list(self.face_to_solid_element.keys()), invert=True)
+            # np.savetxt("non_mapped_2d_elements.dat", self.faces_connectivity[rows, :], delimiter=",", fmt="%i")
 
     def get_collapsed_elements(self):
 

--- a/vibra/interface/data/ui_files/plots/acoustic/allowable_pulsations_2d_for_screw_compressor_inputs.ui
+++ b/vibra/interface/data/ui_files/plots/acoustic/allowable_pulsations_2d_for_screw_compressor_inputs.ui
@@ -152,339 +152,7 @@
       <property name="spacing">
        <number>4</number>
       </property>
-      <item row="2" column="0">
-       <widget class="QFrame" name="frame_5">
-        <property name="maximumSize">
-         <size>
-          <width>16777215</width>
-          <height>40</height>
-         </size>
-        </property>
-        <property name="frameShape">
-         <enum>QFrame::Shape::NoFrame</enum>
-        </property>
-        <property name="frameShadow">
-         <enum>QFrame::Shadow::Raised</enum>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_6">
-         <property name="leftMargin">
-          <number>2</number>
-         </property>
-         <property name="topMargin">
-          <number>2</number>
-         </property>
-         <property name="rightMargin">
-          <number>2</number>
-         </property>
-         <property name="bottomMargin">
-          <number>2</number>
-         </property>
-         <property name="horizontalSpacing">
-          <number>6</number>
-         </property>
-         <property name="verticalSpacing">
-          <number>2</number>
-         </property>
-         <item row="0" column="2">
-          <widget class="QComboBox" name="comboBox_selector_filter">
-           <property name="minimumSize">
-            <size>
-             <width>130</width>
-             <height>28</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>130</width>
-             <height>28</height>
-            </size>
-           </property>
-           <property name="font">
-            <font>
-             <pointsize>10</pointsize>
-            </font>
-           </property>
-           <property name="styleSheet">
-            <string notr="true"/>
-           </property>
-           <property name="currentIndex">
-            <number>0</number>
-           </property>
-           <item>
-            <property name="text">
-             <string>Surfaces</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Lines</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Points</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Nodes</string>
-            </property>
-           </item>
-          </widget>
-         </item>
-         <item row="0" column="0">
-          <spacer name="horizontalSpacer_3">
-           <property name="orientation">
-            <enum>Qt::Orientation::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item row="0" column="1">
-          <widget class="QLabel" name="label_2">
-           <property name="minimumSize">
-            <size>
-             <width>110</width>
-             <height>28</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>110</width>
-             <height>28</height>
-            </size>
-           </property>
-           <property name="font">
-            <font>
-             <pointsize>10</pointsize>
-            </font>
-           </property>
-           <property name="text">
-            <string>Selector filter: </string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="3">
-          <widget class="QFrame" name="frame_6">
-           <property name="minimumSize">
-            <size>
-             <width>44</width>
-             <height>28</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>44</width>
-             <height>28</height>
-            </size>
-           </property>
-           <property name="frameShape">
-            <enum>QFrame::Shape::NoFrame</enum>
-           </property>
-           <property name="frameShadow">
-            <enum>QFrame::Shadow::Raised</enum>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="4">
-          <spacer name="horizontalSpacer_4">
-           <property name="orientation">
-            <enum>Qt::Orientation::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QFrame" name="frame_4">
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>52</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>16777215</width>
-          <height>40</height>
-         </size>
-        </property>
-        <property name="frameShape">
-         <enum>QFrame::Shape::NoFrame</enum>
-        </property>
-        <property name="frameShadow">
-         <enum>QFrame::Shadow::Raised</enum>
-        </property>
-        <layout class="QGridLayout" name="gridLayout">
-         <property name="leftMargin">
-          <number>2</number>
-         </property>
-         <property name="topMargin">
-          <number>2</number>
-         </property>
-         <property name="rightMargin">
-          <number>2</number>
-         </property>
-         <property name="bottomMargin">
-          <number>2</number>
-         </property>
-         <property name="horizontalSpacing">
-          <number>6</number>
-         </property>
-         <property name="verticalSpacing">
-          <number>2</number>
-         </property>
-         <item row="0" column="1">
-          <widget class="QLabel" name="label_10">
-           <property name="minimumSize">
-            <size>
-             <width>110</width>
-             <height>28</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>110</width>
-             <height>28</height>
-            </size>
-           </property>
-           <property name="font">
-            <font>
-             <family>MS Shell Dlg 2</family>
-             <pointsize>10</pointsize>
-             <italic>false</italic>
-             <bold>false</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string>Selected ID: </string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="2">
-          <widget class="QLineEdit" name="lineEdit_selection_id">
-           <property name="minimumSize">
-            <size>
-             <width>130</width>
-             <height>28</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>130</width>
-             <height>28</height>
-            </size>
-           </property>
-           <property name="font">
-            <font>
-             <pointsize>10</pointsize>
-            </font>
-           </property>
-           <property name="styleSheet">
-            <string notr="true"/>
-           </property>
-           <property name="text">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignmentFlag::AlignCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="0">
-          <spacer name="horizontalSpacer">
-           <property name="orientation">
-            <enum>Qt::Orientation::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item row="0" column="3">
-          <widget class="QPushButton" name="pushButton_export_data">
-           <property name="minimumSize">
-            <size>
-             <width>44</width>
-             <height>28</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>44</width>
-             <height>28</height>
-            </size>
-           </property>
-           <property name="font">
-            <font>
-             <family>MS Shell Dlg 2</family>
-             <pointsize>11</pointsize>
-             <italic>false</italic>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt; font-weight:400;&quot;&gt;Press to export the current response function&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-           </property>
-           <property name="styleSheet">
-            <string notr="true"/>
-           </property>
-           <property name="text">
-            <string/>
-           </property>
-           <property name="icon">
-            <iconset resource="../../../icons/dark_theme/resources.qrc">
-             <normaloff>:/icons/save_as.png</normaloff>:/icons/save_as.png</iconset>
-           </property>
-           <property name="iconSize">
-            <size>
-             <width>20</width>
-             <height>20</height>
-            </size>
-           </property>
-           <property name="flat">
-            <bool>false</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="4">
-          <spacer name="horizontalSpacer_2">
-           <property name="orientation">
-            <enum>Qt::Orientation::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item row="6" column="0">
+      <item row="5" column="0">
        <widget class="QFrame" name="frame_3">
         <property name="minimumSize">
          <size>
@@ -553,12 +221,18 @@
         </layout>
        </widget>
       </item>
-      <item row="3" column="0">
-       <widget class="QFrame" name="frame_7">
+      <item row="0" column="0">
+       <widget class="QFrame" name="frame_4">
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>110</height>
+         </size>
+        </property>
         <property name="maximumSize">
          <size>
           <width>16777215</width>
-          <height>40</height>
+          <height>120</height>
          </size>
         </property>
         <property name="frameShape">
@@ -567,9 +241,87 @@
         <property name="frameShadow">
          <enum>QFrame::Shadow::Raised</enum>
         </property>
-        <layout class="QGridLayout" name="gridLayout_5">
+        <layout class="QGridLayout" name="gridLayout">
+         <property name="leftMargin">
+          <number>2</number>
+         </property>
+         <property name="topMargin">
+          <number>6</number>
+         </property>
+         <property name="rightMargin">
+          <number>2</number>
+         </property>
+         <property name="bottomMargin">
+          <number>6</number>
+         </property>
+         <property name="horizontalSpacing">
+          <number>6</number>
+         </property>
+         <property name="verticalSpacing">
+          <number>8</number>
+         </property>
+         <item row="1" column="2">
+          <widget class="QComboBox" name="comboBox_selector_filter">
+           <property name="minimumSize">
+            <size>
+             <width>130</width>
+             <height>28</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>130</width>
+             <height>28</height>
+            </size>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>10</pointsize>
+            </font>
+           </property>
+           <property name="styleSheet">
+            <string notr="true"/>
+           </property>
+           <property name="currentIndex">
+            <number>0</number>
+           </property>
+           <item>
+            <property name="text">
+             <string>Surfaces</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Lines</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Points</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Nodes</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+         <item row="0" column="4">
+          <spacer name="horizontalSpacer_2">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
          <item row="0" column="0">
-          <spacer name="horizontalSpacer_5">
+          <spacer name="horizontalSpacer">
            <property name="orientation">
             <enum>Qt::Orientation::Horizontal</enum>
            </property>
@@ -582,6 +334,139 @@
           </spacer>
          </item>
          <item row="0" column="2">
+          <widget class="QLineEdit" name="lineEdit_selection_id">
+           <property name="minimumSize">
+            <size>
+             <width>130</width>
+             <height>28</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>130</width>
+             <height>28</height>
+            </size>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>10</pointsize>
+            </font>
+           </property>
+           <property name="styleSheet">
+            <string notr="true"/>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignmentFlag::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="3">
+          <widget class="QPushButton" name="pushButton_export_data">
+           <property name="minimumSize">
+            <size>
+             <width>44</width>
+             <height>28</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>44</width>
+             <height>28</height>
+            </size>
+           </property>
+           <property name="font">
+            <font>
+             <family>MS Shell Dlg 2</family>
+             <pointsize>11</pointsize>
+             <italic>false</italic>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt; font-weight:400;&quot;&gt;Press to export the current response function&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="styleSheet">
+            <string notr="true"/>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="icon">
+            <iconset resource="../../../icons/dark_theme/resources.qrc">
+             <normaloff>:/icons/save_as.png</normaloff>:/icons/save_as.png</iconset>
+           </property>
+           <property name="iconSize">
+            <size>
+             <width>20</width>
+             <height>20</height>
+            </size>
+           </property>
+           <property name="flat">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QLabel" name="label_10">
+           <property name="minimumSize">
+            <size>
+             <width>110</width>
+             <height>28</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>110</width>
+             <height>28</height>
+            </size>
+           </property>
+           <property name="font">
+            <font>
+             <family>MS Shell Dlg 2</family>
+             <pointsize>10</pointsize>
+             <italic>false</italic>
+             <bold>false</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>Selected ID: </string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QLabel" name="label_2">
+           <property name="minimumSize">
+            <size>
+             <width>110</width>
+             <height>28</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>110</width>
+             <height>28</height>
+            </size>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>10</pointsize>
+            </font>
+           </property>
+           <property name="text">
+            <string>Selector filter: </string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="2">
           <widget class="QLineEdit" name="lineEdit_selected_fluid">
            <property name="enabled">
             <bool>false</bool>
@@ -614,47 +499,7 @@
            </property>
           </widget>
          </item>
-         <item row="0" column="4">
-          <spacer name="horizontalSpacer_6">
-           <property name="orientation">
-            <enum>Qt::Orientation::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item row="0" column="1">
-          <widget class="QLabel" name="label_31">
-           <property name="minimumSize">
-            <size>
-             <width>110</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>110</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="font">
-            <font>
-             <pointsize>10</pointsize>
-            </font>
-           </property>
-           <property name="text">
-            <string>Selected fluid:</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="3">
+         <item row="2" column="3">
           <widget class="QPushButton" name="pushButton_get_fluid">
            <property name="minimumSize">
             <size>
@@ -691,10 +536,73 @@
            </property>
           </widget>
          </item>
+         <item row="2" column="1">
+          <widget class="QLabel" name="label_31">
+           <property name="minimumSize">
+            <size>
+             <width>110</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>110</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>10</pointsize>
+            </font>
+           </property>
+           <property name="text">
+            <string>Selected fluid:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
         </layout>
        </widget>
       </item>
-      <item row="4" column="0" rowspan="2">
+      <item row="2" column="0">
+       <widget class="QFrame" name="frame_5">
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>40</height>
+         </size>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::Shape::NoFrame</enum>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Shadow::Raised</enum>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_6">
+         <property name="leftMargin">
+          <number>2</number>
+         </property>
+         <property name="topMargin">
+          <number>2</number>
+         </property>
+         <property name="rightMargin">
+          <number>2</number>
+         </property>
+         <property name="bottomMargin">
+          <number>2</number>
+         </property>
+         <property name="horizontalSpacing">
+          <number>6</number>
+         </property>
+         <property name="verticalSpacing">
+          <number>2</number>
+         </property>
+        </layout>
+       </widget>
+      </item>
+      <item row="3" column="0">
        <widget class="QTabWidget" name="tabWidget_main">
         <property name="font">
          <font>
@@ -721,61 +629,7 @@
           <property name="bottomMargin">
            <number>4</number>
           </property>
-          <item row="6" column="0">
-           <widget class="QFrame" name="frame_14">
-            <property name="frameShape">
-             <enum>QFrame::Shape::NoFrame</enum>
-            </property>
-            <property name="frameShadow">
-             <enum>QFrame::Shadow::Raised</enum>
-            </property>
-            <layout class="QGridLayout" name="gridLayout_16">
-             <item row="0" column="2">
-              <spacer name="horizontalSpacer_18">
-               <property name="orientation">
-                <enum>Qt::Orientation::Horizontal</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>40</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-             <item row="0" column="0">
-              <spacer name="horizontalSpacer_17">
-               <property name="orientation">
-                <enum>Qt::Orientation::Horizontal</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>40</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-             <item row="0" column="1">
-              <widget class="QCheckBox" name="checkBox_pre_study_analysis">
-               <property name="minimumSize">
-                <size>
-                 <width>140</width>
-                 <height>0</height>
-                </size>
-               </property>
-               <property name="toolTip">
-                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This option reduces the allowable pulsation levels to 70% of the value calculated by the previous equation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-               </property>
-               <property name="text">
-                <string>Pre-study analysis</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item row="0" column="0">
+          <item row="1" column="0">
            <widget class="QFrame" name="frame_16">
             <property name="minimumSize">
              <size>
@@ -848,143 +702,6 @@
            </widget>
           </item>
           <item row="3" column="0">
-           <widget class="QFrame" name="frame_10">
-            <property name="frameShape">
-             <enum>QFrame::Shape::NoFrame</enum>
-            </property>
-            <property name="frameShadow">
-             <enum>QFrame::Shadow::Raised</enum>
-            </property>
-            <layout class="QGridLayout" name="gridLayout_9">
-             <property name="leftMargin">
-              <number>0</number>
-             </property>
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>0</number>
-             </property>
-             <item row="0" column="4">
-              <spacer name="horizontalSpacer_9">
-               <property name="orientation">
-                <enum>Qt::Orientation::Horizontal</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>40</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-             <item row="0" column="1">
-              <widget class="QLabel" name="label_34">
-               <property name="minimumSize">
-                <size>
-                 <width>140</width>
-                 <height>0</height>
-                </size>
-               </property>
-               <property name="maximumSize">
-                <size>
-                 <width>140</width>
-                 <height>16777215</height>
-                </size>
-               </property>
-               <property name="font">
-                <font>
-                 <pointsize>10</pointsize>
-                </font>
-               </property>
-               <property name="text">
-                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;right&quot;&gt;Speed of sound C&lt;span style=&quot; vertical-align:sub;&quot;&gt;0&lt;/span&gt;:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="3">
-              <widget class="QLabel" name="label_5">
-               <property name="minimumSize">
-                <size>
-                 <width>60</width>
-                 <height>0</height>
-                </size>
-               </property>
-               <property name="maximumSize">
-                <size>
-                 <width>60</width>
-                 <height>16777215</height>
-                </size>
-               </property>
-               <property name="font">
-                <font>
-                 <pointsize>10</pointsize>
-                </font>
-               </property>
-               <property name="text">
-                <string>[m/s]</string>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="2">
-              <widget class="QLineEdit" name="lineEdit_speed_of_sound">
-               <property name="enabled">
-                <bool>false</bool>
-               </property>
-               <property name="minimumSize">
-                <size>
-                 <width>90</width>
-                 <height>28</height>
-                </size>
-               </property>
-               <property name="maximumSize">
-                <size>
-                 <width>100</width>
-                 <height>28</height>
-                </size>
-               </property>
-               <property name="font">
-                <font>
-                 <pointsize>9</pointsize>
-                </font>
-               </property>
-               <property name="focusPolicy">
-                <enum>Qt::FocusPolicy::ClickFocus</enum>
-               </property>
-               <property name="text">
-                <string/>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignmentFlag::AlignCenter</set>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="0">
-              <spacer name="horizontalSpacer_10">
-               <property name="orientation">
-                <enum>Qt::Orientation::Horizontal</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>40</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item row="2" column="0">
            <widget class="QFrame" name="frame_8">
             <property name="frameShape">
              <enum>QFrame::Shape::NoFrame</enum>
@@ -1004,6 +721,9 @@
              </property>
              <property name="bottomMargin">
               <number>0</number>
+             </property>
+             <property name="verticalSpacing">
+              <number>10</number>
              </property>
              <item row="0" column="2">
               <widget class="QLineEdit" name="lineEdit_average_line_pressure">
@@ -1038,8 +758,8 @@
                </property>
               </widget>
              </item>
-             <item row="0" column="3">
-              <widget class="QLabel" name="label_3">
+             <item row="1" column="3">
+              <widget class="QLabel" name="label_5">
                <property name="minimumSize">
                 <size>
                  <width>60</width>
@@ -1058,7 +778,7 @@
                 </font>
                </property>
                <property name="text">
-                <string>[kPa (a)]</string>
+                <string>[m/s]</string>
                </property>
                <property name="alignment">
                 <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
@@ -1092,18 +812,59 @@
                </property>
               </widget>
              </item>
-             <item row="0" column="4">
-              <spacer name="horizontalSpacer_8">
-               <property name="orientation">
-                <enum>Qt::Orientation::Horizontal</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
+             <item row="0" column="3">
+              <widget class="QLabel" name="label_3">
+               <property name="minimumSize">
                 <size>
-                 <width>40</width>
-                 <height>20</height>
+                 <width>60</width>
+                 <height>0</height>
                 </size>
                </property>
-              </spacer>
+               <property name="maximumSize">
+                <size>
+                 <width>60</width>
+                 <height>16777215</height>
+                </size>
+               </property>
+               <property name="font">
+                <font>
+                 <pointsize>10</pointsize>
+                </font>
+               </property>
+               <property name="text">
+                <string>[kPa (a)]</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="1">
+              <widget class="QLabel" name="label_34">
+               <property name="minimumSize">
+                <size>
+                 <width>140</width>
+                 <height>0</height>
+                </size>
+               </property>
+               <property name="maximumSize">
+                <size>
+                 <width>140</width>
+                 <height>16777215</height>
+                </size>
+               </property>
+               <property name="font">
+                <font>
+                 <pointsize>10</pointsize>
+                </font>
+               </property>
+               <property name="text">
+                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;right&quot;&gt;Speed of sound C&lt;span style=&quot; vertical-align:sub;&quot;&gt;0&lt;/span&gt;:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+               </property>
+              </widget>
              </item>
              <item row="0" column="0">
               <spacer name="horizontalSpacer_7">
@@ -1118,8 +879,163 @@
                </property>
               </spacer>
              </item>
+             <item row="1" column="2">
+              <widget class="QLineEdit" name="lineEdit_speed_of_sound">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="minimumSize">
+                <size>
+                 <width>90</width>
+                 <height>28</height>
+                </size>
+               </property>
+               <property name="maximumSize">
+                <size>
+                 <width>100</width>
+                 <height>28</height>
+                </size>
+               </property>
+               <property name="font">
+                <font>
+                 <pointsize>9</pointsize>
+                </font>
+               </property>
+               <property name="focusPolicy">
+                <enum>Qt::FocusPolicy::ClickFocus</enum>
+               </property>
+               <property name="text">
+                <string/>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignmentFlag::AlignCenter</set>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="4">
+              <spacer name="horizontalSpacer_8">
+               <property name="orientation">
+                <enum>Qt::Orientation::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item row="2" column="2">
+              <widget class="QComboBox" name="comboBox_penalization_factor">
+               <property name="minimumSize">
+                <size>
+                 <width>0</width>
+                 <height>26</height>
+                </size>
+               </property>
+               <property name="maximumSize">
+                <size>
+                 <width>16777215</width>
+                 <height>26</height>
+                </size>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="1">
+              <widget class="QLabel" name="label_penalization_factor">
+               <property name="minimumSize">
+                <size>
+                 <width>120</width>
+                 <height>26</height>
+                </size>
+               </property>
+               <property name="maximumSize">
+                <size>
+                 <width>140</width>
+                 <height>26</height>
+                </size>
+               </property>
+               <property name="font">
+                <font>
+                 <pointsize>10</pointsize>
+                </font>
+               </property>
+               <property name="text">
+                <string>Penalization factor:</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="3">
+              <widget class="QLabel" name="label_8">
+               <property name="minimumSize">
+                <size>
+                 <width>0</width>
+                 <height>26</height>
+                </size>
+               </property>
+               <property name="maximumSize">
+                <size>
+                 <width>16777215</width>
+                 <height>26</height>
+                </size>
+               </property>
+               <property name="font">
+                <font>
+                 <pointsize>10</pointsize>
+                </font>
+               </property>
+               <property name="text">
+                <string>[%]</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+               </property>
+              </widget>
+             </item>
             </layout>
            </widget>
+          </item>
+          <item row="0" column="0">
+           <spacer name="verticalSpacer">
+            <property name="orientation">
+             <enum>Qt::Orientation::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item row="4" column="0">
+           <spacer name="verticalSpacer_2">
+            <property name="orientation">
+             <enum>Qt::Orientation::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item row="2" column="0">
+           <spacer name="verticalSpacer_3">
+            <property name="orientation">
+             <enum>Qt::Orientation::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
           </item>
          </layout>
         </widget>

--- a/vibra/interface/data/ui_files/plots/acoustic/allowable_pulsations_3d_plot_for_screw_compressor_inputs.ui
+++ b/vibra/interface/data/ui_files/plots/acoustic/allowable_pulsations_3d_plot_for_screw_compressor_inputs.ui
@@ -164,7 +164,7 @@
       <property name="spacing">
        <number>4</number>
       </property>
-      <item row="0" column="0">
+      <item row="0" column="1">
        <widget class="QFrame" name="frame_9">
         <property name="minimumSize">
          <size>
@@ -197,7 +197,79 @@
          <property name="bottomMargin">
           <number>0</number>
          </property>
-         <item row="0" column="3">
+         <item row="2" column="2">
+          <widget class="QSlider" name="slider_transparency">
+           <property name="minimumSize">
+            <size>
+             <width>176</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>200</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <spacer name="horizontalSpacer_13">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item row="0" column="4">
+          <spacer name="horizontalSpacer_12">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item row="2" column="1">
+          <widget class="QLabel" name="label_4">
+           <property name="minimumSize">
+            <size>
+             <width>120</width>
+             <height>26</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>140</width>
+             <height>26</height>
+            </size>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>10</pointsize>
+            </font>
+           </property>
+           <property name="text">
+            <string>Transparency:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="2">
           <widget class="QFrame" name="frame_11">
            <property name="minimumSize">
             <size>
@@ -312,17 +384,60 @@
            </layout>
           </widget>
          </item>
-         <item row="0" column="1">
-          <widget class="QLabel" name="label_6">
+         <item row="0" column="2">
+          <widget class="QComboBox" name="comboBox_penalization_factor">
            <property name="minimumSize">
             <size>
-             <width>110</width>
+             <width>0</width>
              <height>26</height>
             </size>
            </property>
            <property name="maximumSize">
             <size>
-             <width>110</width>
+             <width>16777215</width>
+             <height>26</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QLabel" name="label_penalization_factor">
+           <property name="minimumSize">
+            <size>
+             <width>120</width>
+             <height>26</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>140</width>
+             <height>26</height>
+            </size>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>10</pointsize>
+            </font>
+           </property>
+           <property name="text">
+            <string>Penalization factor:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QLabel" name="label_6">
+           <property name="minimumSize">
+            <size>
+             <width>120</width>
+             <height>26</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>140</width>
              <height>26</height>
             </size>
            </property>
@@ -339,43 +454,17 @@
            </property>
           </widget>
          </item>
-         <item row="0" column="0">
-          <spacer name="horizontalSpacer_13">
-           <property name="orientation">
-            <enum>Qt::Orientation::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item row="0" column="4">
-          <spacer name="horizontalSpacer_11">
-           <property name="orientation">
-            <enum>Qt::Orientation::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item row="1" column="1">
-          <widget class="QLabel" name="label_4">
+         <item row="0" column="3">
+          <widget class="QLabel" name="label_8">
            <property name="minimumSize">
             <size>
-             <width>110</width>
+             <width>0</width>
              <height>26</height>
             </size>
            </property>
            <property name="maximumSize">
             <size>
-             <width>110</width>
+             <width>16777215</width>
              <height>26</height>
             </size>
            </property>
@@ -385,95 +474,17 @@
             </font>
            </property>
            <property name="text">
-            <string>Transparency:</string>
+            <string>[%]</string>
            </property>
            <property name="alignment">
-            <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+            <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
            </property>
-          </widget>
-         </item>
-         <item row="1" column="3">
-          <widget class="QSlider" name="slider_transparency">
-           <property name="minimumSize">
-            <size>
-             <width>176</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>200</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="orientation">
-            <enum>Qt::Orientation::Horizontal</enum>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0" colspan="5">
-          <widget class="QFrame" name="frame_14">
-           <property name="frameShape">
-            <enum>QFrame::Shape::NoFrame</enum>
-           </property>
-           <property name="frameShadow">
-            <enum>QFrame::Shadow::Raised</enum>
-           </property>
-           <layout class="QGridLayout" name="gridLayout_16">
-            <item row="0" column="2">
-             <spacer name="horizontalSpacer_18">
-              <property name="orientation">
-               <enum>Qt::Orientation::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item row="0" column="0">
-             <spacer name="horizontalSpacer_17">
-              <property name="orientation">
-               <enum>Qt::Orientation::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item row="0" column="1">
-             <widget class="QCheckBox" name="checkBox_pre_study_analysis">
-              <property name="minimumSize">
-               <size>
-                <width>140</width>
-                <height>0</height>
-               </size>
-              </property>
-              <property name="font">
-               <font>
-                <pointsize>10</pointsize>
-               </font>
-              </property>
-              <property name="toolTip">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This option reduces the allowable pulsation levels to 70% of the value calculated by the previous equation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-              </property>
-              <property name="text">
-               <string>Pre-study analysis</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
           </widget>
          </item>
         </layout>
        </widget>
       </item>
-      <item row="1" column="0">
+      <item row="1" column="1">
        <widget class="QFrame" name="frame_3">
         <property name="minimumSize">
          <size>

--- a/vibra/interface/data/ui_files/plots/acoustic/allowable_pulsations_3d_plot_for_screw_compressor_inputs.ui
+++ b/vibra/interface/data/ui_files/plots/acoustic/allowable_pulsations_3d_plot_for_screw_compressor_inputs.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>408</width>
+    <width>455</width>
     <height>240</height>
    </rect>
   </property>
@@ -197,33 +197,6 @@
          <property name="bottomMargin">
           <number>0</number>
          </property>
-         <item row="1" column="1">
-          <widget class="QLabel" name="label_4">
-           <property name="minimumSize">
-            <size>
-             <width>110</width>
-             <height>26</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>110</width>
-             <height>26</height>
-            </size>
-           </property>
-           <property name="font">
-            <font>
-             <pointsize>10</pointsize>
-            </font>
-           </property>
-           <property name="text">
-            <string>Transparency:</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
          <item row="0" column="3">
           <widget class="QFrame" name="frame_11">
            <property name="minimumSize">
@@ -339,22 +312,30 @@
            </layout>
           </widget>
          </item>
-         <item row="1" column="3">
-          <widget class="QSlider" name="slider_transparency">
+         <item row="0" column="1">
+          <widget class="QLabel" name="label_6">
            <property name="minimumSize">
             <size>
-             <width>176</width>
-             <height>0</height>
+             <width>110</width>
+             <height>26</height>
             </size>
            </property>
            <property name="maximumSize">
             <size>
-             <width>200</width>
-             <height>16777215</height>
+             <width>110</width>
+             <height>26</height>
             </size>
            </property>
-           <property name="orientation">
-            <enum>Qt::Orientation::Horizontal</enum>
+           <property name="font">
+            <font>
+             <pointsize>10</pointsize>
+            </font>
+           </property>
+           <property name="text">
+            <string>Colormaps:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
            </property>
           </widget>
          </item>
@@ -384,8 +365,8 @@
            </property>
           </spacer>
          </item>
-         <item row="0" column="1">
-          <widget class="QLabel" name="label_6">
+         <item row="1" column="1">
+          <widget class="QLabel" name="label_4">
            <property name="minimumSize">
             <size>
              <width>110</width>
@@ -404,11 +385,89 @@
             </font>
            </property>
            <property name="text">
-            <string>Colormaps:</string>
+            <string>Transparency:</string>
            </property>
            <property name="alignment">
             <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
            </property>
+          </widget>
+         </item>
+         <item row="1" column="3">
+          <widget class="QSlider" name="slider_transparency">
+           <property name="minimumSize">
+            <size>
+             <width>176</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>200</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0" colspan="5">
+          <widget class="QFrame" name="frame_14">
+           <property name="frameShape">
+            <enum>QFrame::Shape::NoFrame</enum>
+           </property>
+           <property name="frameShadow">
+            <enum>QFrame::Shadow::Raised</enum>
+           </property>
+           <layout class="QGridLayout" name="gridLayout_16">
+            <item row="0" column="2">
+             <spacer name="horizontalSpacer_18">
+              <property name="orientation">
+               <enum>Qt::Orientation::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item row="0" column="0">
+             <spacer name="horizontalSpacer_17">
+              <property name="orientation">
+               <enum>Qt::Orientation::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item row="0" column="1">
+             <widget class="QCheckBox" name="checkBox_pre_study_analysis">
+              <property name="minimumSize">
+               <size>
+                <width>140</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="font">
+               <font>
+                <pointsize>10</pointsize>
+               </font>
+              </property>
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This option reduces the allowable pulsation levels to 70% of the value calculated by the previous equation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="text">
+               <string>Pre-study analysis</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </widget>
          </item>
         </layout>

--- a/vibra/interface/model_inputs/acoustic/internal_impedances/perforated_plate_model_inputs.py
+++ b/vibra/interface/model_inputs/acoustic/internal_impedances/perforated_plate_model_inputs.py
@@ -786,9 +786,9 @@ class PerforatedPlateModelInputs(PerforatedPlateModelInputs_UI):
         surface_to_volume_map = {}
 
         # select volumes with reduced number of solid elements to decouple the DOF
-        for surf_id in surface_ids:
-            volumes_from_surface = self.model.mesh.volumes_from_surface.get(surface_id)
-            if volumes_from_surface != 2:
+        for _surface_id in surface_ids:
+            volumes_from_surface = self.model.mesh.volumes_from_surface.get(_surface_id)
+            if len(volumes_from_surface) != 2:
                 continue
 
             n_el1 = len(self.mesh.elements_from_volume.get(volumes_from_surface[0]))
@@ -796,7 +796,7 @@ class PerforatedPlateModelInputs(PerforatedPlateModelInputs_UI):
 
             vol_id = volumes_from_surface[0] if n_el1 > n_el2 else volumes_from_surface[1]
 
-            surface_to_volume_map[surf_id] = vol_id
+            surface_to_volume_map[_surface_id] = vol_id
 
         return surface_to_volume_map
 

--- a/vibra/interface/model_inputs/acoustic/internal_impedances/transfer_impedance_inputs.py
+++ b/vibra/interface/model_inputs/acoustic/internal_impedances/transfer_impedance_inputs.py
@@ -237,9 +237,9 @@ class TransferImpedanceInputs(TransferImpedanceInputs_UI):
         surface_to_volume_map = {}
 
         # select volumes with reduced number of solid elements to decouple the DOF
-        for surf_id in surface_ids:
-            volumes_from_surface = self.model.mesh.volumes_from_surface.get(surface_id)
-            if volumes_from_surface != 2:
+        for _surface_id in surface_ids:
+            volumes_from_surface = self.model.mesh.volumes_from_surface.get(_surface_id)
+            if len(volumes_from_surface) != 2:
                 continue
 
             n_el1 = len(self.mesh.elements_from_volume.get(volumes_from_surface[0]))
@@ -247,7 +247,7 @@ class TransferImpedanceInputs(TransferImpedanceInputs_UI):
 
             vol_id = volumes_from_surface[0] if n_el1 > n_el2 else volumes_from_surface[1]
 
-            surface_to_volume_map[surf_id] = vol_id
+            surface_to_volume_map[_surface_id] = vol_id
 
         return surface_to_volume_map
 

--- a/vibra/interface/model_inputs/dof_decoupling/degrees_of_freedom_decoupling_inputs.py
+++ b/vibra/interface/model_inputs/dof_decoupling/degrees_of_freedom_decoupling_inputs.py
@@ -151,9 +151,9 @@ class DegreesOfFreedomDecouplingInputs(DegreesOfFreedomDecouplingInputs_UI):
         surface_to_volume_map = {}
 
         # select volumes with reduced number of solid elements to decouple the DOF
-        for surf_id in surface_ids:
-            volumes_from_surface = self.model.mesh.volumes_from_surface.get(surface_id)
-            if volumes_from_surface != 2:
+        for _surface_id in surface_ids:
+            volumes_from_surface = self.model.mesh.volumes_from_surface.get(_surface_id)
+            if len(volumes_from_surface) != 2:
                 continue
 
             n_el1 = len(self.mesh.elements_from_volume.get(volumes_from_surface[0]))
@@ -161,7 +161,7 @@ class DegreesOfFreedomDecouplingInputs(DegreesOfFreedomDecouplingInputs_UI):
 
             vol_id = volumes_from_surface[0] if n_el1 > n_el2 else volumes_from_surface[1]
 
-            surface_to_volume_map[surf_id] = vol_id
+            surface_to_volume_map[_surface_id] = vol_id
 
         return surface_to_volume_map
 

--- a/vibra/interface/plots/acoustic/allowable_pulsation_3d_plot_for_screw_compressor_inputs.py
+++ b/vibra/interface/plots/acoustic/allowable_pulsation_3d_plot_for_screw_compressor_inputs.py
@@ -68,6 +68,9 @@ class AllowablePulsations3DPlotForScrewCompressorInputs(AllowablePulsations3dPlo
         # QComboBox connection
         self.comboBox_colormaps.currentIndexChanged.connect(self.update_colormap_type)
 
+        # QCheckBox connection
+        self.checkBox_pre_study_analysis.stateChanged.connect(self.penalize_allowable_pulsation_callback)
+
         # QPushButton
         self.pushButton_plot_data.clicked.connect(self.plot_data_callback)
 
@@ -94,6 +97,13 @@ class AllowablePulsations3DPlotForScrewCompressorInputs(AllowablePulsations3dPlo
     def update_transparency_callback(self):
         transparency = self.slider_transparency.value() / 100
         app().main_window.results_widget.set_analysis_actors_transparency(transparency)
+
+    def penalize_allowable_pulsation_callback(self):
+        curent_render_widget = app().main_window.get_current_render_widget()
+        results_render_widget = app().main_window.results_widget
+
+        if curent_render_widget == results_render_widget:
+            self.plot_data_callback()
 
     def plot_data_callback(self):
 

--- a/vibra/interface/plots/acoustic/allowable_pulsation_3d_plot_for_screw_compressor_inputs.py
+++ b/vibra/interface/plots/acoustic/allowable_pulsation_3d_plot_for_screw_compressor_inputs.py
@@ -19,6 +19,7 @@ class AllowablePulsations3DPlotForScrewCompressorInputs(AllowablePulsations3dPlo
         app().main_window.show_geometry_render_widget()
 
         self._reset_variables()
+        self._add_penalization_values_to_combo_box()
         self._create_connections()
 
         self.load_user_preference_colormap()
@@ -63,19 +64,29 @@ class AllowablePulsations3DPlotForScrewCompressorInputs(AllowablePulsations3dPlo
         self.time_vector = None
         self.plot_setup = None
 
+    def _add_penalization_values_to_combo_box(self):
+        self.comboBox_penalization_factor.clear()
+
+        for value in range(0, 100, 5):
+            self.comboBox_penalization_factor.addItem(str(value))
+
+        tool_tip = "Use this to reduced the allowable pulsation criteria by (1 - penalization) factor. "
+        self.comboBox_penalization_factor.setToolTip(tool_tip)
+        self.label_penalization_factor.setToolTip(tool_tip)
+
     def _create_connections(self):
 
         # QComboBox connection
         self.comboBox_colormaps.currentIndexChanged.connect(self.update_colormap_type)
 
-        # QCheckBox connection
-        self.checkBox_pre_study_analysis.stateChanged.connect(self.penalize_allowable_pulsation_callback)
-
-        # QPushButton
+        # QPushButton connection
         self.pushButton_plot_data.clicked.connect(self.plot_data_callback)
 
         # QSlider connection
         self.slider_transparency.valueChanged.connect(self.update_transparency_callback)
+
+        # QSpinBox connection
+        self.comboBox_penalization_factor.currentIndexChanged.connect(self.penalize_allowable_pulsation_callback)
 
     def load_user_preference_colormap(self):
         try:
@@ -110,7 +121,7 @@ class AllowablePulsations3DPlotForScrewCompressorInputs(AllowablePulsations3dPlo
         plot_setup = AllowablePulsationForScrewCompressorsPlotSetup(
             plot_type=self.get_plot_type(),
             unit="kPa",
-            pre_study_analysis=self.checkBox_pre_study_analysis.isChecked()
+            penalization_factor=int(self.comboBox_penalization_factor.currentText())
         )
 
         if plot_setup == self.plot_setup:

--- a/vibra/interface/plots/acoustic/allowable_pulsation_3d_plot_for_screw_compressor_inputs.py
+++ b/vibra/interface/plots/acoustic/allowable_pulsation_3d_plot_for_screw_compressor_inputs.py
@@ -100,6 +100,7 @@ class AllowablePulsations3DPlotForScrewCompressorInputs(AllowablePulsations3dPlo
         plot_setup = AllowablePulsationForScrewCompressorsPlotSetup(
             plot_type=self.get_plot_type(),
             unit="kPa",
+            pre_study_analysis=self.checkBox_pre_study_analysis.isChecked()
         )
 
         if plot_setup == self.plot_setup:

--- a/vibra/interface/plots/acoustic/allowable_pulsations_2d_plot_for_screw_compressor_inputs.py
+++ b/vibra/interface/plots/acoustic/allowable_pulsations_2d_plot_for_screw_compressor_inputs.py
@@ -24,6 +24,7 @@ class AllowablePulsations2DPlotForScrewCompressorInputs(AllowablePulsations2dFor
         app().main_window.show_geometry_render_widget()
 
         self._reset_variables()
+        self._add_penalization_values_to_combo_box()
         self._create_connections()
 
         self._load_analysis_setup_and_solution()
@@ -56,21 +57,32 @@ class AllowablePulsations2DPlotForScrewCompressorInputs(AllowablePulsations2dFor
         self.fluid_dialog = None
         self.selected_fluid = None
 
-        self.model_results = dict()
+        self.model_results = {}
 
         self.unit_label = "Pa"
         self.selection_types = ["surfaces", "lines", "points", "nodes"]
 
+    def _add_penalization_values_to_combo_box(self):
+        self.comboBox_penalization_factor.clear()
+
+        for value in range(0, 100, 5):
+            self.comboBox_penalization_factor.addItem(str(value))
+
+        tool_tip = "Use this to reduced the allowable pulsation criteria by (1 - penalization) factor. "
+        self.comboBox_penalization_factor.setToolTip(tool_tip)
+        self.label_penalization_factor.setToolTip(tool_tip)
+
     def _create_connections(self):
-        #
+
+        # QComboBox connection
         self.comboBox_selector_filter.currentIndexChanged.connect(self.selection_filter_callback)
-        #
+
+        # QPushButton connection
         self.pushButton_export_data.clicked.connect(self.export_data_callback)
         self.pushButton_get_fluid.clicked.connect(self.get_fluid_callback)
         self.pushButton_plot_data.clicked.connect(self.plot_data_callback)
-        #
+
         app().main_window.selection.selection_changed.connect(self.geometry_selection_callback)
-        #
         self.geometry_selection_callback()
 
     def geometry_selection_callback(self):
@@ -342,7 +354,11 @@ class AllowablePulsations2DPlotForScrewCompressorInputs(AllowablePulsations2dFor
         pulsation_criteria_peak = (allowable_levels_percentual / 200) * P_AM * aux_ones
 
         # penalization factor for pre-study analysis
-        factor = 0.7 if self.checkBox_pre_study_analysis.isChecked() else 1.0
+        penalization_factor = int(self.comboBox_penalization_factor.currentText())
+        factor = penalization_factor / 100
+
+        if penalization_factor:
+            title += f" (penalized in {penalization_factor}%)"
 
         key = ("allowable pulsation limits (upper)", (None))
         legend_label_upper = "Allowable pulsation (upper bound)"

--- a/vibra/interface/plots/acoustic/allowable_pulsations_2d_plot_for_screw_compressor_inputs.py
+++ b/vibra/interface/plots/acoustic/allowable_pulsations_2d_plot_for_screw_compressor_inputs.py
@@ -354,18 +354,19 @@ class AllowablePulsations2DPlotForScrewCompressorInputs(AllowablePulsations2dFor
         pulsation_criteria_peak = (allowable_levels_percentual / 200) * P_AM * aux_ones
 
         # penalization factor for pre-study analysis
-        penalization_factor = int(self.comboBox_penalization_factor.currentText())
-        factor = penalization_factor / 100
+        factor = int(self.comboBox_penalization_factor.currentText())
 
-        if penalization_factor:
-            title += f" (penalized in {penalization_factor}%)"
+        if factor:
+            title += f" (penalized in {factor}%)"
 
         key = ("allowable pulsation limits (upper)", (None))
         legend_label_upper = "Allowable pulsation (upper bound)"
 
+        criteria_values = (1 - (factor / 100)) * pulsation_criteria_peak
+
         self.model_results[key] = { 
             "x_data" : time_vector,
-            "y_data" : factor * pulsation_criteria_peak,
+            "y_data" : criteria_values,
             "x_label" : "Time [s]",
             "y_label" : "Acoustic pressure",
             "title" : title,
@@ -381,7 +382,7 @@ class AllowablePulsations2DPlotForScrewCompressorInputs(AllowablePulsations2dFor
 
         self.model_results[key] = { 
             "x_data" : time_vector,
-            "y_data" : -factor * pulsation_criteria_peak,
+            "y_data" : -criteria_values,
             "x_label" : "Time [s]",
             "y_label" : "Acoustic pressure",
             "title" : title,

--- a/vibra/interface/ui_generated/plots/acoustic/allowable_pulsations_2d_for_screw_compressor_inputs_ui.py
+++ b/vibra/interface/ui_generated/plots/acoustic/allowable_pulsations_2d_for_screw_compressor_inputs_ui.py
@@ -15,9 +15,9 @@ from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
     QFont, QFontDatabase, QGradient, QIcon,
     QImage, QKeySequence, QLinearGradient, QPainter,
     QPalette, QPixmap, QRadialGradient, QTransform)
-from PySide6.QtWidgets import (QApplication, QCheckBox, QComboBox, QFrame,
-    QGridLayout, QLabel, QLineEdit, QPushButton,
-    QSizePolicy, QSpacerItem, QTabWidget, QWidget)
+from PySide6.QtWidgets import (QApplication, QComboBox, QFrame, QGridLayout,
+    QLabel, QLineEdit, QPushButton, QSizePolicy,
+    QSpacerItem, QTabWidget, QWidget)
 
 from vibra.interface.formatters.icons import Icon
 
@@ -71,124 +71,6 @@ class Ui_Form(object):
         self.gridLayout_3.setSpacing(4)
         self.gridLayout_3.setObjectName(u"gridLayout_3")
         self.gridLayout_3.setContentsMargins(4, 4, 4, 4)
-        self.frame_5 = QFrame(self.frame_2)
-        self.frame_5.setObjectName(u"frame_5")
-        self.frame_5.setMaximumSize(QSize(16777215, 40))
-        self.frame_5.setFrameShape(QFrame.Shape.NoFrame)
-        self.frame_5.setFrameShadow(QFrame.Shadow.Raised)
-        self.gridLayout_6 = QGridLayout(self.frame_5)
-        self.gridLayout_6.setObjectName(u"gridLayout_6")
-        self.gridLayout_6.setHorizontalSpacing(6)
-        self.gridLayout_6.setVerticalSpacing(2)
-        self.gridLayout_6.setContentsMargins(2, 2, 2, 2)
-        self.comboBox_selector_filter = QComboBox(self.frame_5)
-        self.comboBox_selector_filter.addItem("")
-        self.comboBox_selector_filter.addItem("")
-        self.comboBox_selector_filter.addItem("")
-        self.comboBox_selector_filter.addItem("")
-        self.comboBox_selector_filter.setObjectName(u"comboBox_selector_filter")
-        self.comboBox_selector_filter.setMinimumSize(QSize(130, 28))
-        self.comboBox_selector_filter.setMaximumSize(QSize(130, 28))
-        font1 = QFont()
-        font1.setPointSize(10)
-        self.comboBox_selector_filter.setFont(font1)
-        self.comboBox_selector_filter.setStyleSheet(u"")
-
-        self.gridLayout_6.addWidget(self.comboBox_selector_filter, 0, 2, 1, 1)
-
-        self.horizontalSpacer_3 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
-
-        self.gridLayout_6.addItem(self.horizontalSpacer_3, 0, 0, 1, 1)
-
-        self.label_2 = QLabel(self.frame_5)
-        self.label_2.setObjectName(u"label_2")
-        self.label_2.setMinimumSize(QSize(110, 28))
-        self.label_2.setMaximumSize(QSize(110, 28))
-        self.label_2.setFont(font1)
-        self.label_2.setAlignment(Qt.AlignmentFlag.AlignRight|Qt.AlignmentFlag.AlignTrailing|Qt.AlignmentFlag.AlignVCenter)
-
-        self.gridLayout_6.addWidget(self.label_2, 0, 1, 1, 1)
-
-        self.frame_6 = QFrame(self.frame_5)
-        self.frame_6.setObjectName(u"frame_6")
-        self.frame_6.setMinimumSize(QSize(44, 28))
-        self.frame_6.setMaximumSize(QSize(44, 28))
-        self.frame_6.setFrameShape(QFrame.Shape.NoFrame)
-        self.frame_6.setFrameShadow(QFrame.Shadow.Raised)
-
-        self.gridLayout_6.addWidget(self.frame_6, 0, 3, 1, 1)
-
-        self.horizontalSpacer_4 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
-
-        self.gridLayout_6.addItem(self.horizontalSpacer_4, 0, 4, 1, 1)
-
-
-        self.gridLayout_3.addWidget(self.frame_5, 2, 0, 1, 1)
-
-        self.frame_4 = QFrame(self.frame_2)
-        self.frame_4.setObjectName(u"frame_4")
-        self.frame_4.setMinimumSize(QSize(0, 52))
-        self.frame_4.setMaximumSize(QSize(16777215, 40))
-        self.frame_4.setFrameShape(QFrame.Shape.NoFrame)
-        self.frame_4.setFrameShadow(QFrame.Shadow.Raised)
-        self.gridLayout = QGridLayout(self.frame_4)
-        self.gridLayout.setObjectName(u"gridLayout")
-        self.gridLayout.setHorizontalSpacing(6)
-        self.gridLayout.setVerticalSpacing(2)
-        self.gridLayout.setContentsMargins(2, 2, 2, 2)
-        self.label_10 = QLabel(self.frame_4)
-        self.label_10.setObjectName(u"label_10")
-        self.label_10.setMinimumSize(QSize(110, 28))
-        self.label_10.setMaximumSize(QSize(110, 28))
-        font2 = QFont()
-        font2.setFamilies([u"MS Shell Dlg 2"])
-        font2.setPointSize(10)
-        font2.setBold(False)
-        font2.setItalic(False)
-        self.label_10.setFont(font2)
-        self.label_10.setAlignment(Qt.AlignmentFlag.AlignRight|Qt.AlignmentFlag.AlignTrailing|Qt.AlignmentFlag.AlignVCenter)
-
-        self.gridLayout.addWidget(self.label_10, 0, 1, 1, 1)
-
-        self.lineEdit_selection_id = QLineEdit(self.frame_4)
-        self.lineEdit_selection_id.setObjectName(u"lineEdit_selection_id")
-        self.lineEdit_selection_id.setMinimumSize(QSize(130, 28))
-        self.lineEdit_selection_id.setMaximumSize(QSize(130, 28))
-        self.lineEdit_selection_id.setFont(font1)
-        self.lineEdit_selection_id.setStyleSheet(u"")
-        self.lineEdit_selection_id.setAlignment(Qt.AlignmentFlag.AlignCenter)
-
-        self.gridLayout.addWidget(self.lineEdit_selection_id, 0, 2, 1, 1)
-
-        self.horizontalSpacer = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
-
-        self.gridLayout.addItem(self.horizontalSpacer, 0, 0, 1, 1)
-
-        self.pushButton_export_data = QPushButton(self.frame_4)
-        self.pushButton_export_data.setObjectName(u"pushButton_export_data")
-        self.pushButton_export_data.setMinimumSize(QSize(44, 28))
-        self.pushButton_export_data.setMaximumSize(QSize(44, 28))
-        font3 = QFont()
-        font3.setFamilies([u"MS Shell Dlg 2"])
-        font3.setPointSize(11)
-        font3.setBold(True)
-        font3.setItalic(False)
-        self.pushButton_export_data.setFont(font3)
-        self.pushButton_export_data.setStyleSheet(u"")
-        icon = Icon(u":/icons/save_as.png")
-        self.pushButton_export_data.setIcon(icon)
-        self.pushButton_export_data.setIconSize(QSize(20, 20))
-        self.pushButton_export_data.setFlat(False)
-
-        self.gridLayout.addWidget(self.pushButton_export_data, 0, 3, 1, 1)
-
-        self.horizontalSpacer_2 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
-
-        self.gridLayout.addItem(self.horizontalSpacer_2, 0, 4, 1, 1)
-
-
-        self.gridLayout_3.addWidget(self.frame_4, 0, 0, 1, 1)
-
         self.frame_3 = QFrame(self.frame_2)
         self.frame_3.setObjectName(u"frame_3")
         self.frame_3.setMinimumSize(QSize(0, 52))
@@ -203,6 +85,8 @@ class Ui_Form(object):
         self.pushButton_plot_data.setObjectName(u"pushButton_plot_data")
         self.pushButton_plot_data.setMinimumSize(QSize(100, 32))
         self.pushButton_plot_data.setMaximumSize(QSize(100, 32))
+        font1 = QFont()
+        font1.setPointSize(10)
         self.pushButton_plot_data.setFont(font1)
         self.pushButton_plot_data.setStyleSheet(u"")
         self.pushButton_plot_data.setFlat(False)
@@ -210,20 +94,92 @@ class Ui_Form(object):
         self.gridLayout_47.addWidget(self.pushButton_plot_data, 0, 0, 1, 1)
 
 
-        self.gridLayout_3.addWidget(self.frame_3, 6, 0, 1, 1)
+        self.gridLayout_3.addWidget(self.frame_3, 5, 0, 1, 1)
 
-        self.frame_7 = QFrame(self.frame_2)
-        self.frame_7.setObjectName(u"frame_7")
-        self.frame_7.setMaximumSize(QSize(16777215, 40))
-        self.frame_7.setFrameShape(QFrame.Shape.NoFrame)
-        self.frame_7.setFrameShadow(QFrame.Shadow.Raised)
-        self.gridLayout_5 = QGridLayout(self.frame_7)
-        self.gridLayout_5.setObjectName(u"gridLayout_5")
-        self.horizontalSpacer_5 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.frame_4 = QFrame(self.frame_2)
+        self.frame_4.setObjectName(u"frame_4")
+        self.frame_4.setMinimumSize(QSize(0, 110))
+        self.frame_4.setMaximumSize(QSize(16777215, 120))
+        self.frame_4.setFrameShape(QFrame.Shape.NoFrame)
+        self.frame_4.setFrameShadow(QFrame.Shadow.Raised)
+        self.gridLayout = QGridLayout(self.frame_4)
+        self.gridLayout.setObjectName(u"gridLayout")
+        self.gridLayout.setHorizontalSpacing(6)
+        self.gridLayout.setVerticalSpacing(8)
+        self.gridLayout.setContentsMargins(2, 6, 2, 6)
+        self.comboBox_selector_filter = QComboBox(self.frame_4)
+        self.comboBox_selector_filter.addItem("")
+        self.comboBox_selector_filter.addItem("")
+        self.comboBox_selector_filter.addItem("")
+        self.comboBox_selector_filter.addItem("")
+        self.comboBox_selector_filter.setObjectName(u"comboBox_selector_filter")
+        self.comboBox_selector_filter.setMinimumSize(QSize(130, 28))
+        self.comboBox_selector_filter.setMaximumSize(QSize(130, 28))
+        self.comboBox_selector_filter.setFont(font1)
+        self.comboBox_selector_filter.setStyleSheet(u"")
 
-        self.gridLayout_5.addItem(self.horizontalSpacer_5, 0, 0, 1, 1)
+        self.gridLayout.addWidget(self.comboBox_selector_filter, 1, 2, 1, 1)
 
-        self.lineEdit_selected_fluid = QLineEdit(self.frame_7)
+        self.horizontalSpacer_2 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+
+        self.gridLayout.addItem(self.horizontalSpacer_2, 0, 4, 1, 1)
+
+        self.horizontalSpacer = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+
+        self.gridLayout.addItem(self.horizontalSpacer, 0, 0, 1, 1)
+
+        self.lineEdit_selection_id = QLineEdit(self.frame_4)
+        self.lineEdit_selection_id.setObjectName(u"lineEdit_selection_id")
+        self.lineEdit_selection_id.setMinimumSize(QSize(130, 28))
+        self.lineEdit_selection_id.setMaximumSize(QSize(130, 28))
+        self.lineEdit_selection_id.setFont(font1)
+        self.lineEdit_selection_id.setStyleSheet(u"")
+        self.lineEdit_selection_id.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
+        self.gridLayout.addWidget(self.lineEdit_selection_id, 0, 2, 1, 1)
+
+        self.pushButton_export_data = QPushButton(self.frame_4)
+        self.pushButton_export_data.setObjectName(u"pushButton_export_data")
+        self.pushButton_export_data.setMinimumSize(QSize(44, 28))
+        self.pushButton_export_data.setMaximumSize(QSize(44, 28))
+        font2 = QFont()
+        font2.setFamilies([u"MS Shell Dlg 2"])
+        font2.setPointSize(11)
+        font2.setBold(True)
+        font2.setItalic(False)
+        self.pushButton_export_data.setFont(font2)
+        self.pushButton_export_data.setStyleSheet(u"")
+        icon = Icon(u":/icons/save_as.png")
+        self.pushButton_export_data.setIcon(icon)
+        self.pushButton_export_data.setIconSize(QSize(20, 20))
+        self.pushButton_export_data.setFlat(False)
+
+        self.gridLayout.addWidget(self.pushButton_export_data, 0, 3, 1, 1)
+
+        self.label_10 = QLabel(self.frame_4)
+        self.label_10.setObjectName(u"label_10")
+        self.label_10.setMinimumSize(QSize(110, 28))
+        self.label_10.setMaximumSize(QSize(110, 28))
+        font3 = QFont()
+        font3.setFamilies([u"MS Shell Dlg 2"])
+        font3.setPointSize(10)
+        font3.setBold(False)
+        font3.setItalic(False)
+        self.label_10.setFont(font3)
+        self.label_10.setAlignment(Qt.AlignmentFlag.AlignRight|Qt.AlignmentFlag.AlignTrailing|Qt.AlignmentFlag.AlignVCenter)
+
+        self.gridLayout.addWidget(self.label_10, 0, 1, 1, 1)
+
+        self.label_2 = QLabel(self.frame_4)
+        self.label_2.setObjectName(u"label_2")
+        self.label_2.setMinimumSize(QSize(110, 28))
+        self.label_2.setMaximumSize(QSize(110, 28))
+        self.label_2.setFont(font1)
+        self.label_2.setAlignment(Qt.AlignmentFlag.AlignRight|Qt.AlignmentFlag.AlignTrailing|Qt.AlignmentFlag.AlignVCenter)
+
+        self.gridLayout.addWidget(self.label_2, 1, 1, 1, 1)
+
+        self.lineEdit_selected_fluid = QLineEdit(self.frame_4)
         self.lineEdit_selected_fluid.setObjectName(u"lineEdit_selected_fluid")
         self.lineEdit_selected_fluid.setEnabled(False)
         self.lineEdit_selected_fluid.setMinimumSize(QSize(130, 28))
@@ -234,22 +190,9 @@ class Ui_Form(object):
         self.lineEdit_selected_fluid.setFocusPolicy(Qt.FocusPolicy.ClickFocus)
         self.lineEdit_selected_fluid.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
-        self.gridLayout_5.addWidget(self.lineEdit_selected_fluid, 0, 2, 1, 1)
+        self.gridLayout.addWidget(self.lineEdit_selected_fluid, 2, 2, 1, 1)
 
-        self.horizontalSpacer_6 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
-
-        self.gridLayout_5.addItem(self.horizontalSpacer_6, 0, 4, 1, 1)
-
-        self.label_31 = QLabel(self.frame_7)
-        self.label_31.setObjectName(u"label_31")
-        self.label_31.setMinimumSize(QSize(110, 0))
-        self.label_31.setMaximumSize(QSize(110, 16777215))
-        self.label_31.setFont(font1)
-        self.label_31.setAlignment(Qt.AlignmentFlag.AlignRight|Qt.AlignmentFlag.AlignTrailing|Qt.AlignmentFlag.AlignVCenter)
-
-        self.gridLayout_5.addWidget(self.label_31, 0, 1, 1, 1)
-
-        self.pushButton_get_fluid = QPushButton(self.frame_7)
+        self.pushButton_get_fluid = QPushButton(self.frame_4)
         self.pushButton_get_fluid.setObjectName(u"pushButton_get_fluid")
         self.pushButton_get_fluid.setMinimumSize(QSize(44, 0))
         self.pushButton_get_fluid.setMaximumSize(QSize(44, 28))
@@ -258,10 +201,32 @@ class Ui_Form(object):
         self.pushButton_get_fluid.setIcon(icon1)
         self.pushButton_get_fluid.setIconSize(QSize(20, 20))
 
-        self.gridLayout_5.addWidget(self.pushButton_get_fluid, 0, 3, 1, 1)
+        self.gridLayout.addWidget(self.pushButton_get_fluid, 2, 3, 1, 1)
+
+        self.label_31 = QLabel(self.frame_4)
+        self.label_31.setObjectName(u"label_31")
+        self.label_31.setMinimumSize(QSize(110, 0))
+        self.label_31.setMaximumSize(QSize(110, 16777215))
+        self.label_31.setFont(font1)
+        self.label_31.setAlignment(Qt.AlignmentFlag.AlignRight|Qt.AlignmentFlag.AlignTrailing|Qt.AlignmentFlag.AlignVCenter)
+
+        self.gridLayout.addWidget(self.label_31, 2, 1, 1, 1)
 
 
-        self.gridLayout_3.addWidget(self.frame_7, 3, 0, 1, 1)
+        self.gridLayout_3.addWidget(self.frame_4, 0, 0, 1, 1)
+
+        self.frame_5 = QFrame(self.frame_2)
+        self.frame_5.setObjectName(u"frame_5")
+        self.frame_5.setMaximumSize(QSize(16777215, 40))
+        self.frame_5.setFrameShape(QFrame.Shape.NoFrame)
+        self.frame_5.setFrameShadow(QFrame.Shadow.Raised)
+        self.gridLayout_6 = QGridLayout(self.frame_5)
+        self.gridLayout_6.setObjectName(u"gridLayout_6")
+        self.gridLayout_6.setHorizontalSpacing(6)
+        self.gridLayout_6.setVerticalSpacing(2)
+        self.gridLayout_6.setContentsMargins(2, 2, 2, 2)
+
+        self.gridLayout_3.addWidget(self.frame_5, 2, 0, 1, 1)
 
         self.tabWidget_main = QTabWidget(self.frame_2)
         self.tabWidget_main.setObjectName(u"tabWidget_main")
@@ -271,29 +236,6 @@ class Ui_Form(object):
         self.gridLayout_10 = QGridLayout(self.tab_allowable_pulsation)
         self.gridLayout_10.setObjectName(u"gridLayout_10")
         self.gridLayout_10.setContentsMargins(4, 4, 4, 4)
-        self.frame_14 = QFrame(self.tab_allowable_pulsation)
-        self.frame_14.setObjectName(u"frame_14")
-        self.frame_14.setFrameShape(QFrame.Shape.NoFrame)
-        self.frame_14.setFrameShadow(QFrame.Shadow.Raised)
-        self.gridLayout_16 = QGridLayout(self.frame_14)
-        self.gridLayout_16.setObjectName(u"gridLayout_16")
-        self.horizontalSpacer_18 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
-
-        self.gridLayout_16.addItem(self.horizontalSpacer_18, 0, 2, 1, 1)
-
-        self.horizontalSpacer_17 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
-
-        self.gridLayout_16.addItem(self.horizontalSpacer_17, 0, 0, 1, 1)
-
-        self.checkBox_pre_study_analysis = QCheckBox(self.frame_14)
-        self.checkBox_pre_study_analysis.setObjectName(u"checkBox_pre_study_analysis")
-        self.checkBox_pre_study_analysis.setMinimumSize(QSize(140, 0))
-
-        self.gridLayout_16.addWidget(self.checkBox_pre_study_analysis, 0, 1, 1, 1)
-
-
-        self.gridLayout_10.addWidget(self.frame_14, 6, 0, 1, 1)
-
         self.frame_16 = QFrame(self.tab_allowable_pulsation)
         self.frame_16.setObjectName(u"frame_16")
         self.frame_16.setMinimumSize(QSize(0, 40))
@@ -315,56 +257,7 @@ class Ui_Form(object):
         self.gridLayout_15.addWidget(self.label_12, 0, 0, 1, 1)
 
 
-        self.gridLayout_10.addWidget(self.frame_16, 0, 0, 1, 1)
-
-        self.frame_10 = QFrame(self.tab_allowable_pulsation)
-        self.frame_10.setObjectName(u"frame_10")
-        self.frame_10.setFrameShape(QFrame.Shape.NoFrame)
-        self.frame_10.setFrameShadow(QFrame.Shadow.Raised)
-        self.gridLayout_9 = QGridLayout(self.frame_10)
-        self.gridLayout_9.setObjectName(u"gridLayout_9")
-        self.gridLayout_9.setContentsMargins(0, 0, 0, 0)
-        self.horizontalSpacer_9 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
-
-        self.gridLayout_9.addItem(self.horizontalSpacer_9, 0, 4, 1, 1)
-
-        self.label_34 = QLabel(self.frame_10)
-        self.label_34.setObjectName(u"label_34")
-        self.label_34.setMinimumSize(QSize(140, 0))
-        self.label_34.setMaximumSize(QSize(140, 16777215))
-        self.label_34.setFont(font1)
-        self.label_34.setAlignment(Qt.AlignmentFlag.AlignRight|Qt.AlignmentFlag.AlignTrailing|Qt.AlignmentFlag.AlignVCenter)
-
-        self.gridLayout_9.addWidget(self.label_34, 0, 1, 1, 1)
-
-        self.label_5 = QLabel(self.frame_10)
-        self.label_5.setObjectName(u"label_5")
-        self.label_5.setMinimumSize(QSize(60, 0))
-        self.label_5.setMaximumSize(QSize(60, 16777215))
-        self.label_5.setFont(font1)
-        self.label_5.setAlignment(Qt.AlignmentFlag.AlignLeading|Qt.AlignmentFlag.AlignLeft|Qt.AlignmentFlag.AlignVCenter)
-
-        self.gridLayout_9.addWidget(self.label_5, 0, 3, 1, 1)
-
-        self.lineEdit_speed_of_sound = QLineEdit(self.frame_10)
-        self.lineEdit_speed_of_sound.setObjectName(u"lineEdit_speed_of_sound")
-        self.lineEdit_speed_of_sound.setEnabled(False)
-        self.lineEdit_speed_of_sound.setMinimumSize(QSize(90, 28))
-        self.lineEdit_speed_of_sound.setMaximumSize(QSize(100, 28))
-        font5 = QFont()
-        font5.setPointSize(9)
-        self.lineEdit_speed_of_sound.setFont(font5)
-        self.lineEdit_speed_of_sound.setFocusPolicy(Qt.FocusPolicy.ClickFocus)
-        self.lineEdit_speed_of_sound.setAlignment(Qt.AlignmentFlag.AlignCenter)
-
-        self.gridLayout_9.addWidget(self.lineEdit_speed_of_sound, 0, 2, 1, 1)
-
-        self.horizontalSpacer_10 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
-
-        self.gridLayout_9.addItem(self.horizontalSpacer_10, 0, 0, 1, 1)
-
-
-        self.gridLayout_10.addWidget(self.frame_10, 3, 0, 1, 1)
+        self.gridLayout_10.addWidget(self.frame_16, 1, 0, 1, 1)
 
         self.frame_8 = QFrame(self.tab_allowable_pulsation)
         self.frame_8.setObjectName(u"frame_8")
@@ -372,26 +265,29 @@ class Ui_Form(object):
         self.frame_8.setFrameShadow(QFrame.Shadow.Raised)
         self.gridLayout_7 = QGridLayout(self.frame_8)
         self.gridLayout_7.setObjectName(u"gridLayout_7")
+        self.gridLayout_7.setVerticalSpacing(10)
         self.gridLayout_7.setContentsMargins(0, 0, 0, 0)
         self.lineEdit_average_line_pressure = QLineEdit(self.frame_8)
         self.lineEdit_average_line_pressure.setObjectName(u"lineEdit_average_line_pressure")
         self.lineEdit_average_line_pressure.setEnabled(False)
         self.lineEdit_average_line_pressure.setMinimumSize(QSize(90, 28))
         self.lineEdit_average_line_pressure.setMaximumSize(QSize(100, 28))
+        font5 = QFont()
+        font5.setPointSize(9)
         self.lineEdit_average_line_pressure.setFont(font5)
         self.lineEdit_average_line_pressure.setFocusPolicy(Qt.FocusPolicy.ClickFocus)
         self.lineEdit_average_line_pressure.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
         self.gridLayout_7.addWidget(self.lineEdit_average_line_pressure, 0, 2, 1, 1)
 
-        self.label_3 = QLabel(self.frame_8)
-        self.label_3.setObjectName(u"label_3")
-        self.label_3.setMinimumSize(QSize(60, 0))
-        self.label_3.setMaximumSize(QSize(60, 16777215))
-        self.label_3.setFont(font1)
-        self.label_3.setAlignment(Qt.AlignmentFlag.AlignLeading|Qt.AlignmentFlag.AlignLeft|Qt.AlignmentFlag.AlignVCenter)
+        self.label_5 = QLabel(self.frame_8)
+        self.label_5.setObjectName(u"label_5")
+        self.label_5.setMinimumSize(QSize(60, 0))
+        self.label_5.setMaximumSize(QSize(60, 16777215))
+        self.label_5.setFont(font1)
+        self.label_5.setAlignment(Qt.AlignmentFlag.AlignLeading|Qt.AlignmentFlag.AlignLeft|Qt.AlignmentFlag.AlignVCenter)
 
-        self.gridLayout_7.addWidget(self.label_3, 0, 3, 1, 1)
+        self.gridLayout_7.addWidget(self.label_5, 1, 3, 1, 1)
 
         self.label_32 = QLabel(self.frame_8)
         self.label_32.setObjectName(u"label_32")
@@ -402,20 +298,86 @@ class Ui_Form(object):
 
         self.gridLayout_7.addWidget(self.label_32, 0, 1, 1, 1)
 
-        self.horizontalSpacer_8 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.label_3 = QLabel(self.frame_8)
+        self.label_3.setObjectName(u"label_3")
+        self.label_3.setMinimumSize(QSize(60, 0))
+        self.label_3.setMaximumSize(QSize(60, 16777215))
+        self.label_3.setFont(font1)
+        self.label_3.setAlignment(Qt.AlignmentFlag.AlignLeading|Qt.AlignmentFlag.AlignLeft|Qt.AlignmentFlag.AlignVCenter)
 
-        self.gridLayout_7.addItem(self.horizontalSpacer_8, 0, 4, 1, 1)
+        self.gridLayout_7.addWidget(self.label_3, 0, 3, 1, 1)
+
+        self.label_34 = QLabel(self.frame_8)
+        self.label_34.setObjectName(u"label_34")
+        self.label_34.setMinimumSize(QSize(140, 0))
+        self.label_34.setMaximumSize(QSize(140, 16777215))
+        self.label_34.setFont(font1)
+        self.label_34.setAlignment(Qt.AlignmentFlag.AlignRight|Qt.AlignmentFlag.AlignTrailing|Qt.AlignmentFlag.AlignVCenter)
+
+        self.gridLayout_7.addWidget(self.label_34, 1, 1, 1, 1)
 
         self.horizontalSpacer_7 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
 
         self.gridLayout_7.addItem(self.horizontalSpacer_7, 0, 0, 1, 1)
 
+        self.lineEdit_speed_of_sound = QLineEdit(self.frame_8)
+        self.lineEdit_speed_of_sound.setObjectName(u"lineEdit_speed_of_sound")
+        self.lineEdit_speed_of_sound.setEnabled(False)
+        self.lineEdit_speed_of_sound.setMinimumSize(QSize(90, 28))
+        self.lineEdit_speed_of_sound.setMaximumSize(QSize(100, 28))
+        self.lineEdit_speed_of_sound.setFont(font5)
+        self.lineEdit_speed_of_sound.setFocusPolicy(Qt.FocusPolicy.ClickFocus)
+        self.lineEdit_speed_of_sound.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
-        self.gridLayout_10.addWidget(self.frame_8, 2, 0, 1, 1)
+        self.gridLayout_7.addWidget(self.lineEdit_speed_of_sound, 1, 2, 1, 1)
+
+        self.horizontalSpacer_8 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+
+        self.gridLayout_7.addItem(self.horizontalSpacer_8, 0, 4, 1, 1)
+
+        self.comboBox_penalization_factor = QComboBox(self.frame_8)
+        self.comboBox_penalization_factor.setObjectName(u"comboBox_penalization_factor")
+        self.comboBox_penalization_factor.setMinimumSize(QSize(0, 26))
+        self.comboBox_penalization_factor.setMaximumSize(QSize(16777215, 26))
+
+        self.gridLayout_7.addWidget(self.comboBox_penalization_factor, 2, 2, 1, 1)
+
+        self.label_penalization_factor = QLabel(self.frame_8)
+        self.label_penalization_factor.setObjectName(u"label_penalization_factor")
+        self.label_penalization_factor.setMinimumSize(QSize(120, 26))
+        self.label_penalization_factor.setMaximumSize(QSize(140, 26))
+        self.label_penalization_factor.setFont(font1)
+        self.label_penalization_factor.setAlignment(Qt.AlignmentFlag.AlignRight|Qt.AlignmentFlag.AlignTrailing|Qt.AlignmentFlag.AlignVCenter)
+
+        self.gridLayout_7.addWidget(self.label_penalization_factor, 2, 1, 1, 1)
+
+        self.label_8 = QLabel(self.frame_8)
+        self.label_8.setObjectName(u"label_8")
+        self.label_8.setMinimumSize(QSize(0, 26))
+        self.label_8.setMaximumSize(QSize(16777215, 26))
+        self.label_8.setFont(font1)
+        self.label_8.setAlignment(Qt.AlignmentFlag.AlignLeading|Qt.AlignmentFlag.AlignLeft|Qt.AlignmentFlag.AlignVCenter)
+
+        self.gridLayout_7.addWidget(self.label_8, 2, 3, 1, 1)
+
+
+        self.gridLayout_10.addWidget(self.frame_8, 3, 0, 1, 1)
+
+        self.verticalSpacer = QSpacerItem(20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
+
+        self.gridLayout_10.addItem(self.verticalSpacer, 0, 0, 1, 1)
+
+        self.verticalSpacer_2 = QSpacerItem(20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
+
+        self.gridLayout_10.addItem(self.verticalSpacer_2, 4, 0, 1, 1)
+
+        self.verticalSpacer_3 = QSpacerItem(20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
+
+        self.gridLayout_10.addItem(self.verticalSpacer_3, 2, 0, 1, 1)
 
         self.tabWidget_main.addTab(self.tab_allowable_pulsation, "")
 
-        self.gridLayout_3.addWidget(self.tabWidget_main, 4, 0, 2, 1)
+        self.gridLayout_3.addWidget(self.tabWidget_main, 3, 0, 1, 1)
 
 
         self.gridLayout_4.addWidget(self.frame_2, 1, 0, 1, 1)
@@ -433,39 +395,37 @@ class Ui_Form(object):
     def retranslateUi(self, Form):
         Form.setWindowTitle(QCoreApplication.translate("Form", u"Form", None))
         self.label.setText(QCoreApplication.translate("Form", u"Allowable pulsations for screw compressor", None))
+        self.pushButton_plot_data.setText(QCoreApplication.translate("Form", u"Plot data", None))
         self.comboBox_selector_filter.setItemText(0, QCoreApplication.translate("Form", u"Surfaces", None))
         self.comboBox_selector_filter.setItemText(1, QCoreApplication.translate("Form", u"Lines", None))
         self.comboBox_selector_filter.setItemText(2, QCoreApplication.translate("Form", u"Points", None))
         self.comboBox_selector_filter.setItemText(3, QCoreApplication.translate("Form", u"Nodes", None))
 
-        self.label_2.setText(QCoreApplication.translate("Form", u"Selector filter: ", None))
-        self.label_10.setText(QCoreApplication.translate("Form", u"Selected ID: ", None))
         self.lineEdit_selection_id.setText("")
 #if QT_CONFIG(tooltip)
         self.pushButton_export_data.setToolTip(QCoreApplication.translate("Form", u"<html><head/><body><p><span style=\" font-size:10pt; font-weight:400;\">Press to export the current response function</span></p></body></html>", None))
 #endif // QT_CONFIG(tooltip)
         self.pushButton_export_data.setText("")
-        self.pushButton_plot_data.setText(QCoreApplication.translate("Form", u"Plot data", None))
+        self.label_10.setText(QCoreApplication.translate("Form", u"Selected ID: ", None))
+        self.label_2.setText(QCoreApplication.translate("Form", u"Selector filter: ", None))
         self.lineEdit_selected_fluid.setText("")
-        self.label_31.setText(QCoreApplication.translate("Form", u"Selected fluid:", None))
 #if QT_CONFIG(tooltip)
         self.pushButton_get_fluid.setToolTip(QCoreApplication.translate("Form", u"<html><head/><body><p>Get fluid from library</p></body></html>", None))
 #endif // QT_CONFIG(tooltip)
         self.pushButton_get_fluid.setText("")
-#if QT_CONFIG(tooltip)
-        self.checkBox_pre_study_analysis.setToolTip(QCoreApplication.translate("Form", u"<html><head/><body><p>This option reduces the allowable pulsation levels to 70% of the value calculated by the previous equation.</p></body></html>", None))
-#endif // QT_CONFIG(tooltip)
-        self.checkBox_pre_study_analysis.setText(QCoreApplication.translate("Form", u"Pre-study analysis", None))
+        self.label_31.setText(QCoreApplication.translate("Form", u"Selected fluid:", None))
 #if QT_CONFIG(tooltip)
         self.label_12.setToolTip(QCoreApplication.translate("Form", u"<html><head/><body><p>Allowable peak-to-peak pulsation levels as a percentage of the absolute mean line pressure in kPa.</p></body></html>", None))
 #endif // QT_CONFIG(tooltip)
         self.label_12.setText(QCoreApplication.translate("Form", u"<html><head/><body><p>P<span style=\" vertical-align:sub;\">p-p</span> = min{2; 28.6 / P<span style=\" vertical-align:sub;\">AM</span><span style=\" vertical-align:super;\">1/3</span>} [%]</p></body></html>", None))
-        self.label_34.setText(QCoreApplication.translate("Form", u"<html><head/><body><p align=\"right\">Speed of sound C<span style=\" vertical-align:sub;\">0</span>:</p></body></html>", None))
-        self.label_5.setText(QCoreApplication.translate("Form", u"[m/s]", None))
-        self.lineEdit_speed_of_sound.setText("")
         self.lineEdit_average_line_pressure.setText("")
-        self.label_3.setText(QCoreApplication.translate("Form", u"[kPa (a)]", None))
+        self.label_5.setText(QCoreApplication.translate("Form", u"[m/s]", None))
         self.label_32.setText(QCoreApplication.translate("Form", u"<html><head/><body><p align=\"right\">Avg. line pressure P<span style=\" vertical-align:sub;\">AM</span>:</p></body></html>", None))
+        self.label_3.setText(QCoreApplication.translate("Form", u"[kPa (a)]", None))
+        self.label_34.setText(QCoreApplication.translate("Form", u"<html><head/><body><p align=\"right\">Speed of sound C<span style=\" vertical-align:sub;\">0</span>:</p></body></html>", None))
+        self.lineEdit_speed_of_sound.setText("")
+        self.label_penalization_factor.setText(QCoreApplication.translate("Form", u"Penalization factor:", None))
+        self.label_8.setText(QCoreApplication.translate("Form", u"[%]", None))
         self.tabWidget_main.setTabText(self.tabWidget_main.indexOf(self.tab_allowable_pulsation), QCoreApplication.translate("Form", u"Allowable pulsation levels", None))
     # retranslateUi
 
@@ -481,43 +441,38 @@ class AllowablePulsations2dForScrewCompressorInputs_UI(QWidget, Ui_Form):
                             - label: QLabel
                 - frame_2: QFrame
                     - (Layout): QGridLayout
-                            - frame_5: QFrame
-                                - (Layout): QGridLayout
-                                        - comboBox_selector_filter: QComboBox
-                                        - label_2: QLabel
-                                        - frame_6: QFrame
-                            - frame_4: QFrame
-                                - (Layout): QGridLayout
-                                        - label_10: QLabel
-                                        - lineEdit_selection_id: QLineEdit
-                                        - pushButton_export_data: QPushButton
                             - frame_3: QFrame
                                 - (Layout): QGridLayout
                                         - pushButton_plot_data: QPushButton
-                            - frame_7: QFrame
+                            - frame_4: QFrame
                                 - (Layout): QGridLayout
+                                        - comboBox_selector_filter: QComboBox
+                                        - lineEdit_selection_id: QLineEdit
+                                        - pushButton_export_data: QPushButton
+                                        - label_10: QLabel
+                                        - label_2: QLabel
                                         - lineEdit_selected_fluid: QLineEdit
-                                        - label_31: QLabel
                                         - pushButton_get_fluid: QPushButton
+                                        - label_31: QLabel
+                            - frame_5: QFrame
+                                - (Layout): QGridLayout
                             - tabWidget_main: QTabWidget
                                 - tab_allowable_pulsation: QWidget
                                     - (Layout): QGridLayout
-                                            - frame_14: QFrame
-                                                - (Layout): QGridLayout
-                                                        - checkBox_pre_study_analysis: QCheckBox
                                             - frame_16: QFrame
                                                 - (Layout): QGridLayout
                                                         - label_12: QLabel
-                                            - frame_10: QFrame
-                                                - (Layout): QGridLayout
-                                                        - label_34: QLabel
-                                                        - label_5: QLabel
-                                                        - lineEdit_speed_of_sound: QLineEdit
                                             - frame_8: QFrame
                                                 - (Layout): QGridLayout
                                                         - lineEdit_average_line_pressure: QLineEdit
-                                                        - label_3: QLabel
+                                                        - label_5: QLabel
                                                         - label_32: QLabel
+                                                        - label_3: QLabel
+                                                        - label_34: QLabel
+                                                        - lineEdit_speed_of_sound: QLineEdit
+                                                        - comboBox_penalization_factor: QComboBox
+                                                        - label_penalization_factor: QLabel
+                                                        - label_8: QLabel
     """
 
     def __init__(self, *args, **kwargs):

--- a/vibra/interface/ui_generated/plots/acoustic/allowable_pulsations_3d_plot_for_screw_compressor_inputs_ui.py
+++ b/vibra/interface/ui_generated/plots/acoustic/allowable_pulsations_3d_plot_for_screw_compressor_inputs_ui.py
@@ -15,15 +15,15 @@ from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
     QFont, QFontDatabase, QGradient, QIcon,
     QImage, QKeySequence, QLinearGradient, QPainter,
     QPalette, QPixmap, QRadialGradient, QTransform)
-from PySide6.QtWidgets import (QApplication, QComboBox, QFrame, QGridLayout,
-    QLabel, QPushButton, QSizePolicy, QSlider,
-    QSpacerItem, QWidget)
+from PySide6.QtWidgets import (QApplication, QCheckBox, QComboBox, QFrame,
+    QGridLayout, QLabel, QPushButton, QSizePolicy,
+    QSlider, QSpacerItem, QWidget)
 
 class Ui_Form(object):
     def setupUi(self, Form):
         if not Form.objectName():
             Form.setObjectName(u"Form")
-        Form.resize(408, 240)
+        Form.resize(455, 240)
         Form.setMinimumSize(QSize(0, 200))
         Form.setMaximumSize(QSize(16777215, 240))
         self.gridLayout_4 = QGridLayout(Form)
@@ -80,17 +80,6 @@ class Ui_Form(object):
         self.gridLayout_13 = QGridLayout(self.frame_9)
         self.gridLayout_13.setObjectName(u"gridLayout_13")
         self.gridLayout_13.setContentsMargins(0, 6, 0, 0)
-        self.label_4 = QLabel(self.frame_9)
-        self.label_4.setObjectName(u"label_4")
-        self.label_4.setMinimumSize(QSize(110, 26))
-        self.label_4.setMaximumSize(QSize(110, 26))
-        font1 = QFont()
-        font1.setPointSize(10)
-        self.label_4.setFont(font1)
-        self.label_4.setAlignment(Qt.AlignmentFlag.AlignRight|Qt.AlignmentFlag.AlignTrailing|Qt.AlignmentFlag.AlignVCenter)
-
-        self.gridLayout_13.addWidget(self.label_4, 1, 1, 1, 1)
-
         self.frame_11 = QFrame(self.frame_9)
         self.frame_11.setObjectName(u"frame_11")
         self.frame_11.setMinimumSize(QSize(176, 0))
@@ -116,28 +105,14 @@ class Ui_Form(object):
         self.comboBox_colormaps.setObjectName(u"comboBox_colormaps")
         self.comboBox_colormaps.setMinimumSize(QSize(120, 26))
         self.comboBox_colormaps.setMaximumSize(QSize(200, 26))
+        font1 = QFont()
+        font1.setPointSize(10)
         self.comboBox_colormaps.setFont(font1)
 
         self.gridLayout_14.addWidget(self.comboBox_colormaps, 0, 0, 1, 1)
 
 
         self.gridLayout_13.addWidget(self.frame_11, 0, 3, 1, 1)
-
-        self.slider_transparency = QSlider(self.frame_9)
-        self.slider_transparency.setObjectName(u"slider_transparency")
-        self.slider_transparency.setMinimumSize(QSize(176, 0))
-        self.slider_transparency.setMaximumSize(QSize(200, 16777215))
-        self.slider_transparency.setOrientation(Qt.Orientation.Horizontal)
-
-        self.gridLayout_13.addWidget(self.slider_transparency, 1, 3, 1, 1)
-
-        self.horizontalSpacer_13 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
-
-        self.gridLayout_13.addItem(self.horizontalSpacer_13, 0, 0, 1, 1)
-
-        self.horizontalSpacer_11 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
-
-        self.gridLayout_13.addItem(self.horizontalSpacer_11, 0, 4, 1, 1)
 
         self.label_6 = QLabel(self.frame_9)
         self.label_6.setObjectName(u"label_6")
@@ -147,6 +122,55 @@ class Ui_Form(object):
         self.label_6.setAlignment(Qt.AlignmentFlag.AlignRight|Qt.AlignmentFlag.AlignTrailing|Qt.AlignmentFlag.AlignVCenter)
 
         self.gridLayout_13.addWidget(self.label_6, 0, 1, 1, 1)
+
+        self.horizontalSpacer_13 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+
+        self.gridLayout_13.addItem(self.horizontalSpacer_13, 0, 0, 1, 1)
+
+        self.horizontalSpacer_11 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+
+        self.gridLayout_13.addItem(self.horizontalSpacer_11, 0, 4, 1, 1)
+
+        self.label_4 = QLabel(self.frame_9)
+        self.label_4.setObjectName(u"label_4")
+        self.label_4.setMinimumSize(QSize(110, 26))
+        self.label_4.setMaximumSize(QSize(110, 26))
+        self.label_4.setFont(font1)
+        self.label_4.setAlignment(Qt.AlignmentFlag.AlignRight|Qt.AlignmentFlag.AlignTrailing|Qt.AlignmentFlag.AlignVCenter)
+
+        self.gridLayout_13.addWidget(self.label_4, 1, 1, 1, 1)
+
+        self.slider_transparency = QSlider(self.frame_9)
+        self.slider_transparency.setObjectName(u"slider_transparency")
+        self.slider_transparency.setMinimumSize(QSize(176, 0))
+        self.slider_transparency.setMaximumSize(QSize(200, 16777215))
+        self.slider_transparency.setOrientation(Qt.Orientation.Horizontal)
+
+        self.gridLayout_13.addWidget(self.slider_transparency, 1, 3, 1, 1)
+
+        self.frame_14 = QFrame(self.frame_9)
+        self.frame_14.setObjectName(u"frame_14")
+        self.frame_14.setFrameShape(QFrame.Shape.NoFrame)
+        self.frame_14.setFrameShadow(QFrame.Shadow.Raised)
+        self.gridLayout_16 = QGridLayout(self.frame_14)
+        self.gridLayout_16.setObjectName(u"gridLayout_16")
+        self.horizontalSpacer_18 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+
+        self.gridLayout_16.addItem(self.horizontalSpacer_18, 0, 2, 1, 1)
+
+        self.horizontalSpacer_17 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+
+        self.gridLayout_16.addItem(self.horizontalSpacer_17, 0, 0, 1, 1)
+
+        self.checkBox_pre_study_analysis = QCheckBox(self.frame_14)
+        self.checkBox_pre_study_analysis.setObjectName(u"checkBox_pre_study_analysis")
+        self.checkBox_pre_study_analysis.setMinimumSize(QSize(140, 0))
+        self.checkBox_pre_study_analysis.setFont(font1)
+
+        self.gridLayout_16.addWidget(self.checkBox_pre_study_analysis, 0, 1, 1, 1)
+
+
+        self.gridLayout_13.addWidget(self.frame_14, 2, 0, 1, 5)
 
 
         self.gridLayout_8.addWidget(self.frame_9, 0, 0, 1, 1)
@@ -186,7 +210,6 @@ class Ui_Form(object):
     def retranslateUi(self, Form):
         Form.setWindowTitle(QCoreApplication.translate("Form", u"Form", None))
         self.label.setText(QCoreApplication.translate("Form", u"Allowable pulsations field plot for screw compressors", None))
-        self.label_4.setText(QCoreApplication.translate("Form", u"Transparency:", None))
         self.comboBox_colormaps.setItemText(0, QCoreApplication.translate("Form", u"Jet scale", None))
         self.comboBox_colormaps.setItemText(1, QCoreApplication.translate("Form", u"Viridis scale", None))
         self.comboBox_colormaps.setItemText(2, QCoreApplication.translate("Form", u"Inferno scale", None))
@@ -200,6 +223,11 @@ class Ui_Form(object):
         self.comboBox_colormaps.setItemText(10, QCoreApplication.translate("Form", u"Grayscale", None))
 
         self.label_6.setText(QCoreApplication.translate("Form", u"Colormaps:", None))
+        self.label_4.setText(QCoreApplication.translate("Form", u"Transparency:", None))
+#if QT_CONFIG(tooltip)
+        self.checkBox_pre_study_analysis.setToolTip(QCoreApplication.translate("Form", u"<html><head/><body><p>This option reduces the allowable pulsation levels to 70% of the value calculated by the previous equation.</p></body></html>", None))
+#endif // QT_CONFIG(tooltip)
+        self.checkBox_pre_study_analysis.setText(QCoreApplication.translate("Form", u"Pre-study analysis", None))
         self.pushButton_plot_data.setText(QCoreApplication.translate("Form", u"Plot data", None))
     # retranslateUi
 
@@ -217,12 +245,15 @@ class AllowablePulsations3dPlotForScrewCompressorInputs_UI(QWidget, Ui_Form):
                     - (Layout): QGridLayout
                             - frame_9: QFrame
                                 - (Layout): QGridLayout
-                                        - label_4: QLabel
                                         - frame_11: QFrame
                                             - (Layout): QGridLayout
                                                     - comboBox_colormaps: QComboBox
-                                        - slider_transparency: QSlider
                                         - label_6: QLabel
+                                        - label_4: QLabel
+                                        - slider_transparency: QSlider
+                                        - frame_14: QFrame
+                                            - (Layout): QGridLayout
+                                                    - checkBox_pre_study_analysis: QCheckBox
                             - frame_3: QFrame
                                 - (Layout): QGridLayout
                                         - pushButton_plot_data: QPushButton

--- a/vibra/interface/ui_generated/plots/acoustic/allowable_pulsations_3d_plot_for_screw_compressor_inputs_ui.py
+++ b/vibra/interface/ui_generated/plots/acoustic/allowable_pulsations_3d_plot_for_screw_compressor_inputs_ui.py
@@ -15,9 +15,9 @@ from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
     QFont, QFontDatabase, QGradient, QIcon,
     QImage, QKeySequence, QLinearGradient, QPainter,
     QPalette, QPixmap, QRadialGradient, QTransform)
-from PySide6.QtWidgets import (QApplication, QCheckBox, QComboBox, QFrame,
-    QGridLayout, QLabel, QPushButton, QSizePolicy,
-    QSlider, QSpacerItem, QWidget)
+from PySide6.QtWidgets import (QApplication, QComboBox, QFrame, QGridLayout,
+    QLabel, QPushButton, QSizePolicy, QSlider,
+    QSpacerItem, QWidget)
 
 class Ui_Form(object):
     def setupUi(self, Form):
@@ -80,6 +80,33 @@ class Ui_Form(object):
         self.gridLayout_13 = QGridLayout(self.frame_9)
         self.gridLayout_13.setObjectName(u"gridLayout_13")
         self.gridLayout_13.setContentsMargins(0, 6, 0, 0)
+        self.slider_transparency = QSlider(self.frame_9)
+        self.slider_transparency.setObjectName(u"slider_transparency")
+        self.slider_transparency.setMinimumSize(QSize(176, 0))
+        self.slider_transparency.setMaximumSize(QSize(200, 16777215))
+        self.slider_transparency.setOrientation(Qt.Orientation.Horizontal)
+
+        self.gridLayout_13.addWidget(self.slider_transparency, 2, 2, 1, 1)
+
+        self.horizontalSpacer_13 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+
+        self.gridLayout_13.addItem(self.horizontalSpacer_13, 0, 0, 1, 1)
+
+        self.horizontalSpacer_12 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+
+        self.gridLayout_13.addItem(self.horizontalSpacer_12, 0, 4, 1, 1)
+
+        self.label_4 = QLabel(self.frame_9)
+        self.label_4.setObjectName(u"label_4")
+        self.label_4.setMinimumSize(QSize(120, 26))
+        self.label_4.setMaximumSize(QSize(140, 26))
+        font1 = QFont()
+        font1.setPointSize(10)
+        self.label_4.setFont(font1)
+        self.label_4.setAlignment(Qt.AlignmentFlag.AlignRight|Qt.AlignmentFlag.AlignTrailing|Qt.AlignmentFlag.AlignVCenter)
+
+        self.gridLayout_13.addWidget(self.label_4, 2, 1, 1, 1)
+
         self.frame_11 = QFrame(self.frame_9)
         self.frame_11.setObjectName(u"frame_11")
         self.frame_11.setMinimumSize(QSize(176, 0))
@@ -105,75 +132,49 @@ class Ui_Form(object):
         self.comboBox_colormaps.setObjectName(u"comboBox_colormaps")
         self.comboBox_colormaps.setMinimumSize(QSize(120, 26))
         self.comboBox_colormaps.setMaximumSize(QSize(200, 26))
-        font1 = QFont()
-        font1.setPointSize(10)
         self.comboBox_colormaps.setFont(font1)
 
         self.gridLayout_14.addWidget(self.comboBox_colormaps, 0, 0, 1, 1)
 
 
-        self.gridLayout_13.addWidget(self.frame_11, 0, 3, 1, 1)
+        self.gridLayout_13.addWidget(self.frame_11, 1, 2, 1, 1)
+
+        self.comboBox_penalization_factor = QComboBox(self.frame_9)
+        self.comboBox_penalization_factor.setObjectName(u"comboBox_penalization_factor")
+        self.comboBox_penalization_factor.setMinimumSize(QSize(0, 26))
+        self.comboBox_penalization_factor.setMaximumSize(QSize(16777215, 26))
+
+        self.gridLayout_13.addWidget(self.comboBox_penalization_factor, 0, 2, 1, 1)
+
+        self.label_penalization_factor = QLabel(self.frame_9)
+        self.label_penalization_factor.setObjectName(u"label_penalization_factor")
+        self.label_penalization_factor.setMinimumSize(QSize(120, 26))
+        self.label_penalization_factor.setMaximumSize(QSize(140, 26))
+        self.label_penalization_factor.setFont(font1)
+        self.label_penalization_factor.setAlignment(Qt.AlignmentFlag.AlignRight|Qt.AlignmentFlag.AlignTrailing|Qt.AlignmentFlag.AlignVCenter)
+
+        self.gridLayout_13.addWidget(self.label_penalization_factor, 0, 1, 1, 1)
 
         self.label_6 = QLabel(self.frame_9)
         self.label_6.setObjectName(u"label_6")
-        self.label_6.setMinimumSize(QSize(110, 26))
-        self.label_6.setMaximumSize(QSize(110, 26))
+        self.label_6.setMinimumSize(QSize(120, 26))
+        self.label_6.setMaximumSize(QSize(140, 26))
         self.label_6.setFont(font1)
         self.label_6.setAlignment(Qt.AlignmentFlag.AlignRight|Qt.AlignmentFlag.AlignTrailing|Qt.AlignmentFlag.AlignVCenter)
 
-        self.gridLayout_13.addWidget(self.label_6, 0, 1, 1, 1)
+        self.gridLayout_13.addWidget(self.label_6, 1, 1, 1, 1)
 
-        self.horizontalSpacer_13 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.label_8 = QLabel(self.frame_9)
+        self.label_8.setObjectName(u"label_8")
+        self.label_8.setMinimumSize(QSize(0, 26))
+        self.label_8.setMaximumSize(QSize(16777215, 26))
+        self.label_8.setFont(font1)
+        self.label_8.setAlignment(Qt.AlignmentFlag.AlignLeading|Qt.AlignmentFlag.AlignLeft|Qt.AlignmentFlag.AlignVCenter)
 
-        self.gridLayout_13.addItem(self.horizontalSpacer_13, 0, 0, 1, 1)
-
-        self.horizontalSpacer_11 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
-
-        self.gridLayout_13.addItem(self.horizontalSpacer_11, 0, 4, 1, 1)
-
-        self.label_4 = QLabel(self.frame_9)
-        self.label_4.setObjectName(u"label_4")
-        self.label_4.setMinimumSize(QSize(110, 26))
-        self.label_4.setMaximumSize(QSize(110, 26))
-        self.label_4.setFont(font1)
-        self.label_4.setAlignment(Qt.AlignmentFlag.AlignRight|Qt.AlignmentFlag.AlignTrailing|Qt.AlignmentFlag.AlignVCenter)
-
-        self.gridLayout_13.addWidget(self.label_4, 1, 1, 1, 1)
-
-        self.slider_transparency = QSlider(self.frame_9)
-        self.slider_transparency.setObjectName(u"slider_transparency")
-        self.slider_transparency.setMinimumSize(QSize(176, 0))
-        self.slider_transparency.setMaximumSize(QSize(200, 16777215))
-        self.slider_transparency.setOrientation(Qt.Orientation.Horizontal)
-
-        self.gridLayout_13.addWidget(self.slider_transparency, 1, 3, 1, 1)
-
-        self.frame_14 = QFrame(self.frame_9)
-        self.frame_14.setObjectName(u"frame_14")
-        self.frame_14.setFrameShape(QFrame.Shape.NoFrame)
-        self.frame_14.setFrameShadow(QFrame.Shadow.Raised)
-        self.gridLayout_16 = QGridLayout(self.frame_14)
-        self.gridLayout_16.setObjectName(u"gridLayout_16")
-        self.horizontalSpacer_18 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
-
-        self.gridLayout_16.addItem(self.horizontalSpacer_18, 0, 2, 1, 1)
-
-        self.horizontalSpacer_17 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
-
-        self.gridLayout_16.addItem(self.horizontalSpacer_17, 0, 0, 1, 1)
-
-        self.checkBox_pre_study_analysis = QCheckBox(self.frame_14)
-        self.checkBox_pre_study_analysis.setObjectName(u"checkBox_pre_study_analysis")
-        self.checkBox_pre_study_analysis.setMinimumSize(QSize(140, 0))
-        self.checkBox_pre_study_analysis.setFont(font1)
-
-        self.gridLayout_16.addWidget(self.checkBox_pre_study_analysis, 0, 1, 1, 1)
+        self.gridLayout_13.addWidget(self.label_8, 0, 3, 1, 1)
 
 
-        self.gridLayout_13.addWidget(self.frame_14, 2, 0, 1, 5)
-
-
-        self.gridLayout_8.addWidget(self.frame_9, 0, 0, 1, 1)
+        self.gridLayout_8.addWidget(self.frame_9, 0, 1, 1, 1)
 
         self.frame_3 = QFrame(self.frame_main)
         self.frame_3.setObjectName(u"frame_3")
@@ -196,7 +197,7 @@ class Ui_Form(object):
         self.gridLayout_47.addWidget(self.pushButton_plot_data, 0, 0, 1, 1)
 
 
-        self.gridLayout_8.addWidget(self.frame_3, 1, 0, 1, 1)
+        self.gridLayout_8.addWidget(self.frame_3, 1, 1, 1, 1)
 
 
         self.gridLayout_4.addWidget(self.frame_main, 1, 0, 1, 1)
@@ -210,6 +211,7 @@ class Ui_Form(object):
     def retranslateUi(self, Form):
         Form.setWindowTitle(QCoreApplication.translate("Form", u"Form", None))
         self.label.setText(QCoreApplication.translate("Form", u"Allowable pulsations field plot for screw compressors", None))
+        self.label_4.setText(QCoreApplication.translate("Form", u"Transparency:", None))
         self.comboBox_colormaps.setItemText(0, QCoreApplication.translate("Form", u"Jet scale", None))
         self.comboBox_colormaps.setItemText(1, QCoreApplication.translate("Form", u"Viridis scale", None))
         self.comboBox_colormaps.setItemText(2, QCoreApplication.translate("Form", u"Inferno scale", None))
@@ -222,12 +224,9 @@ class Ui_Form(object):
         self.comboBox_colormaps.setItemText(9, QCoreApplication.translate("Form", u"PuOr diverging scale", None))
         self.comboBox_colormaps.setItemText(10, QCoreApplication.translate("Form", u"Grayscale", None))
 
+        self.label_penalization_factor.setText(QCoreApplication.translate("Form", u"Penalization factor:", None))
         self.label_6.setText(QCoreApplication.translate("Form", u"Colormaps:", None))
-        self.label_4.setText(QCoreApplication.translate("Form", u"Transparency:", None))
-#if QT_CONFIG(tooltip)
-        self.checkBox_pre_study_analysis.setToolTip(QCoreApplication.translate("Form", u"<html><head/><body><p>This option reduces the allowable pulsation levels to 70% of the value calculated by the previous equation.</p></body></html>", None))
-#endif // QT_CONFIG(tooltip)
-        self.checkBox_pre_study_analysis.setText(QCoreApplication.translate("Form", u"Pre-study analysis", None))
+        self.label_8.setText(QCoreApplication.translate("Form", u"[%]", None))
         self.pushButton_plot_data.setText(QCoreApplication.translate("Form", u"Plot data", None))
     # retranslateUi
 
@@ -245,15 +244,15 @@ class AllowablePulsations3dPlotForScrewCompressorInputs_UI(QWidget, Ui_Form):
                     - (Layout): QGridLayout
                             - frame_9: QFrame
                                 - (Layout): QGridLayout
+                                        - slider_transparency: QSlider
+                                        - label_4: QLabel
                                         - frame_11: QFrame
                                             - (Layout): QGridLayout
                                                     - comboBox_colormaps: QComboBox
+                                        - comboBox_penalization_factor: QComboBox
+                                        - label_penalization_factor: QLabel
                                         - label_6: QLabel
-                                        - label_4: QLabel
-                                        - slider_transparency: QSlider
-                                        - frame_14: QFrame
-                                            - (Layout): QGridLayout
-                                                    - checkBox_pre_study_analysis: QCheckBox
+                                        - label_8: QLabel
                             - frame_3: QFrame
                                 - (Layout): QGridLayout
                                         - pushButton_plot_data: QPushButton

--- a/vibra/interface/viewer_3d/plot_setup.py
+++ b/vibra/interface/viewer_3d/plot_setup.py
@@ -60,7 +60,7 @@ class TransientPressurePlotSetup:
 class AllowablePulsationForScrewCompressorsPlotSetup:
     plot_type: PressurePlotType
     unit: str = "--"
-    pre_study_analysis: bool = False
+    penalization_factor: int = 0
 
 
 # Do not forget to add the type here

--- a/vibra/interface/viewer_3d/plot_setup.py
+++ b/vibra/interface/viewer_3d/plot_setup.py
@@ -60,6 +60,7 @@ class TransientPressurePlotSetup:
 class AllowablePulsationForScrewCompressorsPlotSetup:
     plot_type: PressurePlotType
     unit: str = "--"
+    pre_study_analysis: bool = False
 
 
 # Do not forget to add the type here

--- a/vibra/interface/viewer_3d/render_widgets/model_info_text.py
+++ b/vibra/interface/viewer_3d/render_widgets/model_info_text.py
@@ -983,6 +983,18 @@ def analysis_info_text(frequency_index: int):
 
     return str(tree)
 
+def allowable_pulsation_for_screw_compressor_info_text(value: float, pre_study_analysis: bool):
+    analysis_setup = app().project.model.analysis_setup
+    analysis_id = analysis_setup.analysis_id
+    if AnalysisID.ACOUSTIC_HARMONIC != analysis_id:
+        return ""
+
+    tree = TreeInfo("Allowable pulsation for screw compressor systems")
+    tree.add_item("Allowable level (p-p)", value, "kPa")
+    tree.add_item("Pre-study analysis:", "Yes" if pre_study_analysis else "No")
+
+    return str(tree)
+
 def structural_format(property_name, values, labels, units, has_table):
     if all_none(values):
         return ""

--- a/vibra/interface/viewer_3d/render_widgets/model_info_text.py
+++ b/vibra/interface/viewer_3d/render_widgets/model_info_text.py
@@ -983,7 +983,7 @@ def analysis_info_text(frequency_index: int):
 
     return str(tree)
 
-def allowable_pulsation_for_screw_compressor_info_text(value: float, pre_study_analysis: bool):
+def allowable_pulsation_for_screw_compressor_info_text(value: float, penalization_factor: int):
     analysis_setup = app().project.model.analysis_setup
     analysis_id = analysis_setup.analysis_id
     if AnalysisID.ACOUSTIC_HARMONIC != analysis_id:
@@ -991,7 +991,7 @@ def allowable_pulsation_for_screw_compressor_info_text(value: float, pre_study_a
 
     tree = TreeInfo("Allowable pulsation for screw compressor systems")
     tree.add_item("Allowable level (p-p)", value, "kPa")
-    tree.add_item("Pre-study analysis:", "Yes" if pre_study_analysis else "No")
+    tree.add_item("Penalization factor:", penalization_factor, "%")
 
     return str(tree)
 

--- a/vibra/interface/viewer_3d/render_widgets/results_render_widget.py
+++ b/vibra/interface/viewer_3d/render_widgets/results_render_widget.py
@@ -374,8 +374,8 @@ class ResultsRenderWidget(AnimatedRenderWidget):
         color_scalars, min_value, max_value = data
 
         # apply the penalization factor, if necessary
-        penalization_factor = 0.7 if self.plot_setup.pre_study_analysis else 1.0
-        max_value *= penalization_factor
+        penalization_factor = self.plot_setup.penalization_factor / 100
+        max_value *= (1 - penalization_factor)
 
         self.screw_compressor_allowable_pulsation_criterion = max_value
 
@@ -664,7 +664,7 @@ class ResultsRenderWidget(AnimatedRenderWidget):
             case AllowablePulsationForScrewCompressorsPlotSetup():
                 text += allowable_pulsation_for_screw_compressor_info_text(
                     self.screw_compressor_allowable_pulsation_criterion, 
-                    self.plot_setup.pre_study_analysis,
+                    self.plot_setup.penalization_factor,
                     )
 
         self.set_info_text(text)

--- a/vibra/interface/viewer_3d/render_widgets/results_render_widget.py
+++ b/vibra/interface/viewer_3d/render_widgets/results_render_widget.py
@@ -34,6 +34,7 @@ from ..actors import (
 )
 from .model_info_text import (
     analysis_info_text,
+    allowable_pulsation_for_screw_compressor_info_text,
 )
 
 
@@ -56,9 +57,12 @@ class ResultsRenderWidget(AnimatedRenderWidget):
 
         self._animation_cached_data = dict()
         self._animation_cache_lock = Lock()
+
         self.min_value = 0
         self.max_value = 0
         self.transparency = 0
+        self.screw_compressor_allowable_pulsation_criterion = 0
+
         self.is_animation_symetric = True
 
         self.set_default_render_tool()
@@ -369,6 +373,12 @@ class ResultsRenderWidget(AnimatedRenderWidget):
 
         color_scalars, min_value, max_value = data
 
+        # apply the penalization factor, if necessary
+        penalization_factor = 0.7 if self.plot_setup.pre_study_analysis else 1.0
+        max_value *= penalization_factor
+
+        self.screw_compressor_allowable_pulsation_criterion = max_value
+
         if clear_cache:
             self.min_value = min_value
             self.max_value = max_value
@@ -650,6 +660,12 @@ class ResultsRenderWidget(AnimatedRenderWidget):
         match self.plot_setup:
             case FrequencyDisplacementPlotSetup() | FrequencyPressurePlotSetup():
                 text += analysis_info_text(self.plot_setup.index)
+
+            case AllowablePulsationForScrewCompressorsPlotSetup():
+                text += allowable_pulsation_for_screw_compressor_info_text(
+                    self.screw_compressor_allowable_pulsation_criterion, 
+                    self.plot_setup.pre_study_analysis,
+                    )
 
         self.set_info_text(text)
         self.update()


### PR DESCRIPTION
This pull request implements pre-study penalization for the screw compressor system's allowable pulsation 3D plot. I took the opportunity to include minor corrections to address problems found in the input classes for the perforated plate, transfer impedance, and degrees of freedom decoupling.