### PR TITLE
Add "bad elements" edges to the plot

### DIFF
--- a/vibra/interface/viewer_3d/actors/edges_actor.py
+++ b/vibra/interface/viewer_3d/actors/edges_actor.py
@@ -1,8 +1,9 @@
 from typing import Optional
 
 from molde.colors import Color, color_names
+from vtkmodules.vtkCommonCore import vtkIdList
 from vtkmodules.vtkCommonDataModel import vtkPlane
-from vtkmodules.vtkFiltersCore import vtkExtractEdges
+from vtkmodules.vtkFiltersCore import vtkExtractCells, vtkExtractEdges
 from vtkmodules.vtkFiltersExtraction import vtkExtractGeometry
 from vtkmodules.vtkRenderingCore import vtkActor, vtkDataSetMapper
 
@@ -21,6 +22,7 @@ class EdgesActor(vtkActor):
             self.visualization_filter = VisualizationFilter.all_true()
 
         self.mapper = vtkDataSetMapper()
+        self.cell_extractor = vtkExtractCells()
         self.edges_extractor = vtkExtractEdges()
         self.edges_extractor.UseAllPointsOn()
         self.data = None
@@ -32,14 +34,33 @@ class EdgesActor(vtkActor):
         self.configure_appearance()
 
     def extract_data(self, data):
-        if data == self.edges_extractor.GetInput():
+        if data == self.cell_extractor.GetInput():
             return
 
         self.data = data
 
-        self.edges_extractor.SetInputData(data)
+        self.cell_extractor.SetInputData(data)
+        self.cell_extractor.ExtractAllCellsOn()
+        self.cell_extractor.Update()
+        self.edges_extractor.SetInputConnection(self.cell_extractor.GetOutputPort())
         self.edges_extractor.Update()
-        self.mapper.SetInputData(self.edges_extractor.GetOutput())
+        self.mapper.SetInputConnection(self.edges_extractor.GetOutputPort())
+
+    def distinguish_cells(self, cells: tuple[int]):
+        if len(cells) == 0:  # disable if empty -> show all the edges
+            self.cell_extractor.ExtractAllCellsOn()
+            self.cell_extractor.Update()
+            self.mapper.Modified()
+            return
+
+        ids = vtkIdList()
+        for cell in cells:
+            ids.InsertNextId(cell)
+
+        self.cell_extractor.ExtractAllCellsOff()
+        self.cell_extractor.SetCellList(ids)
+        self.cell_extractor.Update()
+        self.mapper.Modified()
 
     def apply_cut(self, origin, normal):
         if self.data is None:
@@ -50,7 +71,7 @@ class EdgesActor(vtkActor):
         plane.SetNormal(normal)
 
         clipper = vtkExtractGeometry()
-        clipper.SetInputData(self.data)
+        clipper.SetInputConnection(self.edges_extractor.GetOutputPort())
         clipper.SetImplicitFunction(plane)
         clipper.ExtractInsideOff()
         clipper.Update()
@@ -67,7 +88,7 @@ class EdgesActor(vtkActor):
 
         self.GetMapper().RemoveAllClippingPlanes()
         self.GetMapper().RemoveAllInputConnections(0)
-        self.GetMapper().SetInputData(self.data)
+        self.GetMapper().SetInputConnection(self.edges_extractor.GetOutputPort())
 
     def configure_appearance(self):
         edges_thickness = app().config.user_preferences.edges_thickness

--- a/vibra/interface/viewer_3d/render_widgets/mesh_render_widget.py
+++ b/vibra/interface/viewer_3d/render_widgets/mesh_render_widget.py
@@ -215,6 +215,8 @@ class MeshRenderWidget(CommonRenderWidget):
             self.switch_to_solids_actor()
             self.solids_actor.distinguish_solids(distinguished_solids)
             self.solids_actor.SetVisibility(True)
+            self.edges_actor.distinguish_cells(self._distinguished_cells(distinguished_solids))
+            self.edges_actor.SetVisibility(visualization.lines)
 
         self.update_selection()
         self.update()
@@ -375,6 +377,14 @@ class MeshRenderWidget(CommonRenderWidget):
         )
         self.add_actors(self.solids_actor, self.edges_actor)
         self.visualization_changed_callback()
+
+    def _distinguished_cells(self, distinguished_solids):
+        cells = []
+        for i in distinguished_solids:
+            visible_index = self.solids_actor.visible_indexes.get(i, -1)
+            if visible_index >= 0:
+                cells.append(visible_index)
+        return cells
 
     def update_section_plane(self):
         if not self.actors_exists():


### PR DESCRIPTION
This PR fixes the simple problem of the bad elements edges not being plotted. 
This makes it easier to identify what's actually going on th the plot.
Closes #422 

Previously:
<img width="1493" height="855" alt="image" src="https://github.com/user-attachments/assets/c62e30ba-9f51-44bb-a302-12c98d98e178" />


Now:
<img width="1392" height="891" alt="image" src="https://github.com/user-attachments/assets/140acc81-fe4e-41b6-a40f-1167aced200c" />

Other example:
<img width="1549" height="818" alt="image" src="https://github.com/user-attachments/assets/63d0067b-e59d-4d80-8c72-893ee7e3c31d" />
<img width="1484" height="729" alt="image" src="https://github.com/user-attachments/assets/ee7076f9-5711-41fe-87b6-4e7aed221138" />


