### PR TITLE
Save visualization filters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,3 +73,4 @@ reportUnknownVariableType = false
 reportUnannotatedClassAttribute = false
 reportMissingTypeStubs = false
 reportUnnecessaryIsInstance = false
+typeCheckingMode = "off"

--- a/vibra/interface/config.py
+++ b/vibra/interface/config.py
@@ -157,11 +157,7 @@ class Config:
         key = workspace.value + "_visualization_filter"
 
         if key not in config_data:
-            if workspace == Workspaces.RESULTS:
-                return VisualizationFilter(faces=True,
-                                           solids=True)
-            
-            return VisualizationFilter.default()
+            return VisualizationFilter.default(workspace)
         
         visualization_filter_data = {}
         for field in fields(VisualizationFilter):

--- a/vibra/interface/config.py
+++ b/vibra/interface/config.py
@@ -164,9 +164,12 @@ class Config:
             visualization_filter_data[field.name] = config_data[key].get(field.name, False)
 
         filter = VisualizationFilter(**visualization_filter_data)
-
-        if filter.is_all_false():
-            filter.faces = True
+        if filter.is_visible(workspace):
+            return filter
+        
+        filter.faces = True
+        if workspace == Workspaces.MESH:
+            filter.solids = True
 
         return filter
 

--- a/vibra/interface/config.py
+++ b/vibra/interface/config.py
@@ -156,22 +156,21 @@ class Config:
         config_data = self.get_config_data()
         key = workspace.value + "_visualization_filter"
 
+        if key not in config_data:
+            if workspace == Workspaces.RESULTS:
+                return VisualizationFilter(faces=True,
+                                           solids=True)
+            
+            return VisualizationFilter.default()
+        
         visualization_filter_data = {}
         for field in fields(VisualizationFilter):
-            if key in config_data:
-                visualization_filter_data[field.name] = config_data[key].get(field.name)
+            visualization_filter_data[field.name] = config_data[key].get(field.name, False)
 
-        if len(visualization_filter_data) != 0:
-            filter = VisualizationFilter(**visualization_filter_data)
+        filter = VisualizationFilter(**visualization_filter_data)
 
-            if filter.is_all_false():
-                filter.faces = True
+        if filter.is_all_false():
+            filter.faces = True
 
-            return filter
-
-        if workspace == Workspaces.RESULTS:
-            return VisualizationFilter(faces=True,
-                                       solids=True)
-
-        return VisualizationFilter.default()
+        return filter
 

--- a/vibra/interface/config.py
+++ b/vibra/interface/config.py
@@ -3,6 +3,7 @@ from dataclasses import fields
 import json
 
 from vibra.interface.user_preferences import UserPreferences
+from vibra.utils.interface_utils import VisualizationFilter
 
 from molde.colors import Color
 
@@ -142,3 +143,21 @@ class Config:
     def write_data_in_file(self, data: dict):
         with open(self.config_path, "w") as file:
             json.dump(data, file, indent=2)
+
+    def write_visualization_filters_in_file(self, visualization_filter: VisualizationFilter):
+        config_data = self.get_config_data()
+        visualization_filter_data = visualization_filter.to_dict()
+
+        self.write_data_in_file(config_data | visualization_filter_data)
+
+    def get_visualization_filter(self) -> VisualizationFilter:
+        config_data = self.get_config_data()
+        visualization_filter_data = {}
+
+        for field in fields(VisualizationFilter):
+            visualization_filter_data[field.name] = config_data.get(field.name)
+
+        if len(visualization_filter_data) == 0:
+            return VisualizationFilter.default()
+
+        return VisualizationFilter(**visualization_filter_data)

--- a/vibra/interface/config.py
+++ b/vibra/interface/config.py
@@ -1,11 +1,12 @@
-from pathlib import Path
-from dataclasses import fields
 import json
-
-from vibra.interface.user_preferences import UserPreferences
-from vibra.utils.interface_utils import VisualizationFilter
+from dataclasses import fields
+from pathlib import Path
 
 from molde.colors import Color
+
+from vibra.interface.enums import Workspaces
+from vibra.interface.user_preferences import UserPreferences
+from vibra.utils.interface_utils import VisualizationFilter
 
 
 class Config:
@@ -144,20 +145,33 @@ class Config:
         with open(self.config_path, "w") as file:
             json.dump(data, file, indent=2)
 
-    def write_visualization_filters_in_file(self, visualization_filter: VisualizationFilter):
+    def write_visualization_filters_in_file(self, workspace: Workspaces, visualization_filter: VisualizationFilter):
         config_data = self.get_config_data()
-        visualization_filter_data = visualization_filter.to_dict()
+        key = workspace.value + "_visualization_filter"
+        config_data[key] = visualization_filter.to_dict()
 
-        self.write_data_in_file(config_data | visualization_filter_data)
+        self.write_data_in_file(config_data)
 
-    def get_visualization_filter(self) -> VisualizationFilter:
+    def get_visualization_filter(self, workspace: Workspaces) -> VisualizationFilter:
         config_data = self.get_config_data()
+        key = workspace.value + "_visualization_filter"
+
         visualization_filter_data = {}
-
         for field in fields(VisualizationFilter):
-            visualization_filter_data[field.name] = config_data.get(field.name)
+            if key in config_data:
+                visualization_filter_data[field.name] = config_data[key].get(field.name)
 
-        if len(visualization_filter_data) == 0:
-            return VisualizationFilter.default()
+        if len(visualization_filter_data) != 0:
+            filter = VisualizationFilter(**visualization_filter_data)
 
-        return VisualizationFilter(**visualization_filter_data)
+            if filter.is_all_false():
+                filter.faces = True
+
+            return filter
+
+        if workspace == Workspaces.RESULTS:
+            return VisualizationFilter(faces=True,
+                                       solids=True)
+
+        return VisualizationFilter.default()
+

--- a/vibra/interface/enums.py
+++ b/vibra/interface/enums.py
@@ -1,0 +1,7 @@
+from enum import StrEnum
+
+
+class Workspaces(StrEnum):
+    GEOMETRY = "geometry"
+    MESH = "mesh"
+    RESULTS = "results"

--- a/vibra/interface/main_window.py
+++ b/vibra/interface/main_window.py
@@ -172,7 +172,6 @@ class MainWindow(MainWindow_UI):
 
         app().splash.update_progress(90)
         self.load_user_preferences()
-        self.load_visualization_filters()
         self.config_tool_tip_appearance()
         self.create_temporary_vibra_folder()
 
@@ -287,10 +286,6 @@ class MainWindow(MainWindow_UI):
         show = app().config.user_preferences.show_reference_scale_bar
         self.update_scale_bar(show)
         self.update_renderer_font_size()
-
-    def load_visualization_filters(self):
-        visualization_filter = app().config.get_visualization_filter(Workspaces.GEOMETRY)
-        self.apply_visualization_filter(visualization_filter)
 
     def create_recents_menu(self):
         self.recent_icon = Icon(":/icons/recent.png")
@@ -537,7 +532,7 @@ class MainWindow(MainWindow_UI):
         self.action_model_workspace.setChecked(False)
         self.action_mesh_workspace.setChecked(False)
 
-        self.render_widgets_stack.setCurrentWidget(self.geometry_widget)
+        self.render_widgets_stack.setCurrentWidget(self.results_widget)
         self.stacked_setup.setCurrentWidget(self.results_viewer_widget)
         self.results_viewer_widget.results_viewer_items.update_items()
         self.analysis_toolbar.update_analysis_combo_boxes()
@@ -1083,14 +1078,16 @@ class MainWindow(MainWindow_UI):
             return None
         return render_widget.visualization_filter
 
-    def get_current_workspace(self) -> Workspaces:
+    def get_current_workspace(self) -> Workspaces | None:
         render_widget = self.get_current_render_widget()
 
         if isinstance(render_widget, GeometryRenderWidget):
             return Workspaces.GEOMETRY
         elif isinstance(render_widget, MeshRenderWidget):
             return Workspaces.MESH
-        return Workspaces.RESULTS
+        elif isinstance(render_widget, ResultsRenderWidget):
+            return Workspaces.RESULTS
+        return None
 
     def visualization_changed_callback(self):
         if visualization_filter := self.get_current_visualization_filter():

--- a/vibra/interface/main_window.py
+++ b/vibra/interface/main_window.py
@@ -19,6 +19,7 @@ from vibra.engine.mesher.mesh_setup import MeshSetup
 from vibra.engine.solvers import HarmonicSolver
 from vibra.interface.data.icons.theme_resources import set_icon_theme
 from vibra.interface.data_handler.export_mesh_data import ExportMeshData
+from vibra.interface.enums import Workspaces
 from vibra.interface.formatters.icons import Icon, get_vibra_icon
 from vibra.interface.general.entity_visibility_handler import EntityVisibilityHandler
 from vibra.interface.general.print_message_input import PrintMessageInput
@@ -288,7 +289,7 @@ class MainWindow(MainWindow_UI):
         self.update_renderer_font_size()
 
     def load_visualization_filters(self):
-        visualization_filter = app().config.get_visualization_filter()
+        visualization_filter = app().config.get_visualization_filter(Workspaces.GEOMETRY)
         self.apply_visualization_filter(visualization_filter)
 
     def create_recents_menu(self):
@@ -1082,6 +1083,15 @@ class MainWindow(MainWindow_UI):
             return None
         return render_widget.visualization_filter
 
+    def get_current_workspace(self) -> Workspaces:
+        render_widget = self.get_current_render_widget()
+
+        if isinstance(render_widget, GeometryRenderWidget):
+            return Workspaces.GEOMETRY
+        elif isinstance(render_widget, MeshRenderWidget):
+            return Workspaces.MESH
+        return Workspaces.RESULTS
+
     def visualization_changed_callback(self):
         if visualization_filter := self.get_current_visualization_filter():
             self.update_visualization_filter(visualization_filter)
@@ -1095,7 +1105,8 @@ class MainWindow(MainWindow_UI):
             self.action_ghost_view.setChecked(filter.ghost)
             self.action_hide_show_symbols.setChecked(filter.symbols)
 
-        self.update_visualization_filters(filter)
+        current_workspace = self.get_current_workspace()
+        app().config.write_visualization_filters_in_file(current_workspace, filter)
 
     def update_visualization_filter(self, filter: VisualizationFilter):
         filter.points = self.action_node_view.isChecked()
@@ -1108,13 +1119,6 @@ class MainWindow(MainWindow_UI):
     def reload_visualization_filter(self):
         if visualization_filter := self.get_current_visualization_filter():
             self.apply_visualization_filter(visualization_filter)
-
-    def update_visualization_filters(self, filter: VisualizationFilter):
-        for render in self.get_renderer_widgets():
-            if hasattr(render, "visualization_filter"):
-                render.visualization_filter = filter
-
-        app().config.write_visualization_filters_in_file(filter)
 
     def action_about_vibra_callback(self):
         self.close_dialogs()

--- a/vibra/interface/main_window.py
+++ b/vibra/interface/main_window.py
@@ -110,7 +110,6 @@ class MainWindow(MainWindow_UI):
         self.render_widgets_stack.currentChanged.connect(self.render_changed_callback)
         self.visualization_changed.connect(self.reload_visualization_filter)
         self.render_widget_changed.connect(self.reload_visualization_filter)
-        self.reload_visualization_filter()
 
         self.stacked_setup.addWidget(self.model_setup_widget)
         self.stacked_setup.addWidget(self.results_viewer_widget)
@@ -172,6 +171,7 @@ class MainWindow(MainWindow_UI):
 
         app().splash.update_progress(90)
         self.load_user_preferences()
+        self.load_visualization_filters()
         self.config_tool_tip_appearance()
         self.create_temporary_vibra_folder()
 
@@ -286,6 +286,10 @@ class MainWindow(MainWindow_UI):
         show = app().config.user_preferences.show_reference_scale_bar
         self.update_scale_bar(show)
         self.update_renderer_font_size()
+
+    def load_visualization_filters(self):
+        visualization_filter = app().config.get_visualization_filter()
+        self.apply_visualization_filter(visualization_filter)
 
     def create_recents_menu(self):
         self.recent_icon = Icon(":/icons/recent.png")
@@ -418,12 +422,6 @@ class MainWindow(MainWindow_UI):
         self.results_viewer_widget.hide_bottom_widget()
         self.results_viewer_widget.results_viewer_items.clear_last_item()
         self.render_widgets_stack.setCurrentWidget(self.geometry_widget)
-
-        self.action_results_workspace.setEnabled(True)
-        self.action_results_workspace.setChecked(True)
-        self.action_mesh_workspace.setChecked(False)
-        self.action_model_workspace.setChecked(False)
-        self.reload_visualization_filter()
 
     def show_geometry_render_widget(self):
         self.render_widgets_stack.setCurrentWidget(self.geometry_widget)
@@ -1095,6 +1093,9 @@ class MainWindow(MainWindow_UI):
             self.action_line_view.setChecked(filter.lines)
             self.action_face_view.setChecked(filter.faces or filter.solids)
             self.action_ghost_view.setChecked(filter.ghost)
+            self.action_hide_show_symbols.setChecked(filter.symbols)
+
+        self.update_visualization_filters(filter)
 
     def update_visualization_filter(self, filter: VisualizationFilter):
         filter.points = self.action_node_view.isChecked()
@@ -1107,6 +1108,13 @@ class MainWindow(MainWindow_UI):
     def reload_visualization_filter(self):
         if visualization_filter := self.get_current_visualization_filter():
             self.apply_visualization_filter(visualization_filter)
+
+    def update_visualization_filters(self, filter: VisualizationFilter):
+        for render in self.get_renderer_widgets():
+            if hasattr(render, "visualization_filter"):
+                render.visualization_filter = filter
+
+        app().config.write_visualization_filters_in_file(filter)
 
     def action_about_vibra_callback(self):
         self.close_dialogs()

--- a/vibra/interface/menus/results_viewer_widget.py
+++ b/vibra/interface/menus/results_viewer_widget.py
@@ -100,6 +100,7 @@ class ResultsViewerWidget(LeftMenuWidget_UI):
         self.plot_structural_modal.configure_results_display_widget()
 
         self.add_widget(self.plot_structural_modal)
+        self.set_results_workspace()
 
     def add_structural_harmonic_widget(self):
         self.top_widget.setFixedHeight(120)
@@ -108,20 +109,25 @@ class ResultsViewerWidget(LeftMenuWidget_UI):
         self.plot_structural_harmonic.configure_results_display_widget()
 
         self.add_widget(self.plot_structural_harmonic)
+        self.set_results_workspace()
 
     def add_acoustic_modal_widget(self):
         self.top_widget.setFixedHeight(220)
         self.current_widget = self.plot_acoustic_modal
         self.plot_acoustic_modal.load_natural_frequencies()
         self.plot_acoustic_modal.configure_results_display_widget()
+
         self.add_widget(self.plot_acoustic_modal)
+        self.set_results_workspace()
 
     def add_acoustic_harmonic_widget(self):
         self.top_widget.setFixedHeight(220)
         self.current_widget = self.plot_acoustic_harmonic
         self.plot_acoustic_harmonic.load_frequencies()
         self.plot_acoustic_harmonic.configure_results_display_widget()
+
         self.add_widget(self.plot_acoustic_harmonic)
+        self.set_results_workspace()
 
     def add_structural_frequency_response_widget(self):
         self.current_widget = app().main_window.input_ui.plot_structural_frequency_response()
@@ -257,3 +263,11 @@ class ResultsViewerWidget(LeftMenuWidget_UI):
 
         self.adjustSize()
         widget.show()
+
+    def set_results_workspace(self):
+        app().main_window.action_results_workspace.setEnabled(True)
+        app().main_window.action_results_workspace.setChecked(True)
+        
+        app().main_window.action_model_workspace.setChecked(False)
+        app().main_window.action_mesh_workspace.setChecked(False)
+        

--- a/vibra/interface/model_inputs/structural/definitions/enums.py
+++ b/vibra/interface/model_inputs/structural/definitions/enums.py
@@ -1,5 +1,6 @@
 from enum import IntEnum
 
+
 class StandardTabType(IntEnum):
     CONSTANT_DATA = 0
     TABULAR_DATA = 1

--- a/vibra/interface/viewer_3d/render_widgets/geometry_render_widget.py
+++ b/vibra/interface/viewer_3d/render_widgets/geometry_render_widget.py
@@ -8,7 +8,6 @@ from PySide6.QtWidgets import QApplication
 
 from vibra import LOGO_DIR, app
 from vibra.utils.image_functions import removes_image_background
-from vibra.utils.interface_utils import VisualizationFilter
 from vibra.utils.time_utils import warn_delays
 
 from ..actors.ghost_actor import GhostActor
@@ -73,12 +72,7 @@ class GeometryRenderWidget(CommonRenderWidget):
         self.renderer.SetOcclusionRatio(0.9)
         self.render_interactor.GetRenderWindow().SetMultiSamples(0)
 
-        self.visualization_filter = VisualizationFilter(
-            lines=True,
-            faces=True,
-            solids=True,
-            symbols=True,
-        )
+        self.visualization_filter = app().config.get_visualization_filter()
 
         self.remove_all_actors()
         self.update_logo()

--- a/vibra/interface/viewer_3d/render_widgets/geometry_render_widget.py
+++ b/vibra/interface/viewer_3d/render_widgets/geometry_render_widget.py
@@ -7,6 +7,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QApplication
 
 from vibra import LOGO_DIR, app
+from vibra.interface.enums import Workspaces
 from vibra.utils.image_functions import removes_image_background
 from vibra.utils.time_utils import warn_delays
 
@@ -72,7 +73,7 @@ class GeometryRenderWidget(CommonRenderWidget):
         self.renderer.SetOcclusionRatio(0.9)
         self.render_interactor.GetRenderWindow().SetMultiSamples(0)
 
-        self.visualization_filter = app().config.get_visualization_filter()
+        self.visualization_filter = app().config.get_visualization_filter(Workspaces.GEOMETRY)
 
         self.remove_all_actors()
         self.update_logo()

--- a/vibra/interface/viewer_3d/render_widgets/mesh_render_widget.py
+++ b/vibra/interface/viewer_3d/render_widgets/mesh_render_widget.py
@@ -203,7 +203,6 @@ class MeshRenderWidget(CommonRenderWidget):
         self.edges_actor.SetVisibility(visualization.lines and not distinguished_solids)
         self.faces_actor.SetVisibility(visualization.faces and not mesh_error)
         self.solids_actor.SetVisibility(visualization.solids and not mesh_error)
-        self.faces_actor.SetVisibility(visualization.faces and not mesh_error)
         self.ghost_actor.SetVisibility(visualization.ghost and app().main_window.has_hidden_part())
 
         if distinguished_solids:

--- a/vibra/interface/viewer_3d/render_widgets/mesh_render_widget.py
+++ b/vibra/interface/viewer_3d/render_widgets/mesh_render_widget.py
@@ -8,7 +8,6 @@ from PySide6.QtWidgets import QApplication
 
 from vibra import LOGO_DIR, app
 from vibra.interface.loading_window import LoadingWindow
-from vibra.utils.interface_utils import VisualizationFilter
 
 from ..actors.edges_actor import EdgesActor
 from ..actors.faces_actor import FacesActor
@@ -33,12 +32,7 @@ class MeshRenderWidget(CommonRenderWidget):
     def __init__(self, parent=None):
         super().__init__(parent)
 
-        self.visualization_filter = VisualizationFilter(
-            lines=True,
-            faces=True,
-            solids=True,
-            symbols=True,
-        )
+        self.visualization_filter = app().config.get_visualization_filter()
 
         self.mesh_selection = MeshSelection(self)
         self.selection_color = (20, 106, 245)

--- a/vibra/interface/viewer_3d/render_widgets/mesh_render_widget.py
+++ b/vibra/interface/viewer_3d/render_widgets/mesh_render_widget.py
@@ -1,4 +1,3 @@
-from vibra.utils.time_utils import warn_delays
 import logging
 
 from molde.colors import Color, color_names
@@ -7,7 +6,9 @@ from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QApplication
 
 from vibra import LOGO_DIR, app
+from vibra.interface.enums import Workspaces
 from vibra.interface.loading_window import LoadingWindow
+from vibra.utils.time_utils import warn_delays
 
 from ..actors.edges_actor import EdgesActor
 from ..actors.faces_actor import FacesActor
@@ -32,7 +33,7 @@ class MeshRenderWidget(CommonRenderWidget):
     def __init__(self, parent=None):
         super().__init__(parent)
 
-        self.visualization_filter = app().config.get_visualization_filter()
+        self.visualization_filter = app().config.get_visualization_filter(Workspaces.MESH)
 
         self.mesh_selection = MeshSelection(self)
         self.selection_color = (20, 106, 245)

--- a/vibra/interface/viewer_3d/render_widgets/results_render_widget.py
+++ b/vibra/interface/viewer_3d/render_widgets/results_render_widget.py
@@ -12,17 +12,17 @@ from vtkmodules.vtkCommonDataModel import vtkPointData
 from vibra import LOGO_DIR, app
 from vibra.engine import AnalysisID
 from vibra.engine.postprocessing import AcousticPostprocessing, StructuralPostprocessing
+from vibra.interface.enums import Workspaces
 from vibra.interface.loading_window import LoadingWindow
 from vibra.interface.viewer_3d.plot_setup import (
+    AllowablePulsationForScrewCompressorsPlotSetup,
     FrequencyDisplacementPlotSetup,
     FrequencyPressurePlotSetup,
     NoPlotSetup,
     PlotSetup,
     TransientPressurePlotSetup,
-    AllowablePulsationForScrewCompressorsPlotSetup,
 )
 from vibra.interface.viewer_3d.render_tools import RenderTool, SelectionTool
-from vibra.utils.interface_utils import VisualizationFilter
 from vibra.utils.time_utils import warn_delays
 
 from ..actors import (
@@ -33,8 +33,8 @@ from ..actors import (
     SectionPlaneActor,
 )
 from .model_info_text import (
-    analysis_info_text,
     allowable_pulsation_for_screw_compressor_info_text,
+    analysis_info_text,
 )
 
 
@@ -48,10 +48,7 @@ class ResultsRenderWidget(AnimatedRenderWidget):
         app().main_window.visualization_changed.connect(self.visualization_changed_callback)
 
         self.plot_setup: PlotSetup = NoPlotSetup()
-        self.visualization_filter = VisualizationFilter(
-            faces=True,
-            solids=True,
-        )
+        self.visualization_filter = app().config.get_visualization_filter(Workspaces.RESULTS)
         # dont't remove, transparency depends on it
         self.renderer.SetUseDepthPeeling(True)
 

--- a/vibra/utils/interface_utils.py
+++ b/vibra/utils/interface_utils.py
@@ -34,8 +34,11 @@ class VisualizationFilter:
     element_normal_symbols: bool = False
     color_mode: GeometryColorMode = GeometryColorMode.COLORED
 
-    def is_all_false(self) -> bool:
-        return not any([self.points, self.lines, self.faces, self.solids, self.symbols])
+    def is_visible(self, workspace: Workspaces) -> bool:
+        if workspace == Workspaces.RESULTS:
+            return any([self.faces, self.lines])
+        
+        return any([self.points, self.lines, self.faces, self.solids])
 
     def to_dict(self) -> dict:
         return {key: value for key, value in asdict(self).items() if value != False}

--- a/vibra/utils/interface_utils.py
+++ b/vibra/utils/interface_utils.py
@@ -33,7 +33,7 @@ class VisualizationFilter:
     color_mode: GeometryColorMode = GeometryColorMode.COLORED
 
     def is_all_false(self) -> bool:
-        return not all([self.points, self.lines, self.faces, self.solids, self.symbols])
+        return not any([self.points, self.lines, self.faces, self.solids, self.symbols])
 
     def to_dict(self) -> dict:
         return asdict(self)

--- a/vibra/utils/interface_utils.py
+++ b/vibra/utils/interface_utils.py
@@ -10,6 +10,8 @@ from PySide6.QtCore import QTimer
 from PySide6.QtWidgets import QWidget
 from vtkmodules.vtkRenderingCore import vtkCoordinate
 
+from vibra.interface.enums import Workspaces
+
 window_title = "Error"
 
 
@@ -45,7 +47,10 @@ class VisualizationFilter:
         return cls(*args)
 
     @classmethod
-    def default(cls):
+    def default(cls, workspace: Workspaces):
+        if workspace == Workspaces.RESULTS:
+            return cls(faces=True, solids=True)
+        
         return cls(lines=True, faces=True, solids=True, symbols=True)
 
 

--- a/vibra/utils/interface_utils.py
+++ b/vibra/utils/interface_utils.py
@@ -1,8 +1,9 @@
+from collections.abc import Generator
 from contextlib import contextmanager
-from dataclasses import dataclass, asdict
+from dataclasses import asdict, dataclass
 from enum import IntEnum, auto
 from functools import partial, wraps
-from typing import Generator, TypeVar
+from typing import TypeVar
 
 import numpy as np
 from PySide6.QtCore import QTimer
@@ -31,12 +32,12 @@ class VisualizationFilter:
     element_normal_symbols: bool = False
     color_mode: GeometryColorMode = GeometryColorMode.COLORED
 
-    @classmethod
-    def all_false(cls):
-        # It is dumb, but it works
-        args = [False] * 8
-        return cls(*args)
+    def is_all_false(self) -> bool:
+        return not all([self.points, self.lines, self.faces, self.solids, self.symbols])
 
+    def to_dict(self) -> dict:
+        return asdict(self)
+    
     @classmethod
     def all_true(cls):
         # It is dumb, but it works
@@ -45,13 +46,8 @@ class VisualizationFilter:
 
     @classmethod
     def default(cls):
-        return cls(lines=True,
-                    faces=True,
-                    solids=True,
-                    symbols=True)
+        return cls(lines=True, faces=True, solids=True, symbols=True)
 
-    def to_dict(self) -> dict:
-        return asdict(self)
 
 T = TypeVar("T", bound=QWidget)
 

--- a/vibra/utils/interface_utils.py
+++ b/vibra/utils/interface_utils.py
@@ -1,5 +1,5 @@
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, asdict
 from enum import IntEnum, auto
 from functools import partial, wraps
 from typing import Generator, TypeVar
@@ -43,6 +43,15 @@ class VisualizationFilter:
         args = [True] * 8
         return cls(*args)
 
+    @classmethod
+    def default(cls):
+        return cls(lines=True,
+                    faces=True,
+                    solids=True,
+                    symbols=True)
+
+    def to_dict(self) -> dict:
+        return asdict(self)
 
 T = TypeVar("T", bound=QWidget)
 

--- a/vibra/utils/interface_utils.py
+++ b/vibra/utils/interface_utils.py
@@ -36,8 +36,8 @@ class VisualizationFilter:
         return not any([self.points, self.lines, self.faces, self.solids, self.symbols])
 
     def to_dict(self) -> dict:
-        return asdict(self)
-    
+        return {key: value for key, value in asdict(self).items() if value != False}
+
     @classmethod
     def all_true(cls):
         # It is dumb, but it works


### PR DESCRIPTION
This MR contains some code modifications to save the visualization filters for each workspace.

Before, every time that we opened the program the visualization filters were recreated, so the user lost all his config. Now, we save each filter in the `vibra_config.json`.

Only the fields that have the value as `True` are saved in the vibra config file.

Closes #451 